### PR TITLE
build.gradle cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: java
 matrix:
   include:
     - jdk: oraclejdk8
-script: travis_retry ./gradlew clean headless allTests coverage coveralls -i
+script: travis_retry ./gradlew -Pheadless=true clean build coveralls
 before_install:
-          - "export DISPLAY=:99.0"
-          - "sh -e /etc/init.d/xvfb start"
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start"
 
 addons:
   apt:

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@
  * For more details take a look at the Java Quickstart chapter in the Gradle
  * user guide available at http://gradle.org/docs/2.2.1/userguide/tutorial_java_projects.html
  */
- 
+
 plugins {
     id "com.github.kt3k.coveralls" version "2.4.0"
     id "com.github.johnrengelman.shadow" version '1.2.3'
@@ -61,7 +61,7 @@ allprojects {
         }
         testCompile "org.testfx:openjfx-monocle:$monocleVersion"
     }
-    
+
     sourceSets {
         main {
             java {
@@ -72,7 +72,7 @@ allprojects {
             }
         }
     }
-    
+
     shadowJar {
         archiveName = "addressbook.jar"
 
@@ -119,7 +119,7 @@ tasks.coveralls {
 
 class AddressBookTest extends Test {
     public AddressBookTest() {
-    	  forkEvery = 1
+        forkEvery = 1
         systemProperty 'testfx.setup.timeout', '60000'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@
 
 plugins {
     id 'java'
+    id 'application'
     id 'jacoco'
     id 'checkstyle'
     id 'com.github.kt3k.coveralls' version '2.4.0'
@@ -22,6 +23,7 @@ repositories {
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+mainClassName = 'seedu.address.MainApp'
 ext {
     if (!has('headless'))
         headless = 'false'
@@ -46,11 +48,6 @@ dependencies {
 
 shadowJar {
     archiveName = "addressbook.jar"
-
-    manifest {
-        attributes "Main-Class": "seedu.address.MainApp"
-    }
-
     destinationDir = file("${buildDir}/jar/")
 }
 
@@ -87,5 +84,9 @@ jacocoTestReport {
 }
 
 tasks.coveralls.dependsOn jacocoTestReport
+
+artifacts {
+    archives shadowJar
+}
 
 defaultTasks 'build'

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ checkstyle {
 }
 
 test {
-    forkEvery = 1
+    forkEvery = 100
     systemProperty 'testfx.setup.timeout', '60000'
     testLogging.exceptionFormat = 'full'
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ plugins {
 }
 
 allprojects {
-    apply plugin: 'idea'
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'checkstyle'

--- a/build.gradle
+++ b/build.gradle
@@ -6,86 +6,72 @@
  */
 
 plugins {
-    id "com.github.kt3k.coveralls" version "2.4.0"
-    id "com.github.johnrengelman.shadow" version '1.2.3'
+    id 'java'
+    id 'jacoco'
+    id 'checkstyle'
+    id 'com.github.kt3k.coveralls' version '2.4.0'
+    id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
-allprojects {
-    apply plugin: 'java'
-    apply plugin: 'jacoco'
-    apply plugin: 'checkstyle'
+repositories {
+    jcenter()
+    mavenCentral()
+    maven { url "https://repo.eclipse.org/content/repositories/egit-releases/" }
+    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+}
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
-    repositories {
-        jcenter()
-        mavenCentral()
-        maven { url "https://repo.eclipse.org/content/repositories/egit-releases/" }
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+// This part is similar to global variables
+// Access them by using double-quoted strings (GStrings) and referencing by $ e.g. "Variable contains $Variable"
+project.ext {
+    controlsFxVersion = '8.40.11'
+    guavaVersion = '19.0'
+    jacksonVersion = '2.7.0'
+    jacksonDataTypeVersion = '2.7.4'
+    junitVersion = '4.12'
+    testFxVersion = '4.0.+'
+    monocleVersion = '1.8.0_20'
+
+    libDir = 'lib'
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled false
+        csv.enabled false
+        html.destination "${buildDir}/jacocoHtml"
+    }
+}
+
+dependencies {
+    compile "org.controlsfx:controlsfx:$controlsFxVersion"
+    compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
+    compile "com.google.guava:guava:$guavaVersion"
+
+    testCompile "junit:junit:$junitVersion"
+    testCompile "org.testfx:testfx-core:$testFxVersion"
+    testCompile "org.testfx:testfx-junit:$testFxVersion"
+    testCompile "org.testfx:testfx-legacy:$testFxVersion", {
+        exclude group: "junit", module: "junit"
+    }
+    testCompile "org.testfx:openjfx-monocle:$monocleVersion"
+}
+
+shadowJar {
+    archiveName = "addressbook.jar"
+
+    manifest {
+        attributes "Main-Class": "seedu.address.MainApp"
     }
 
-    // This part is similar to global variables
-    // Access them by using double-quoted strings (GStrings) and referencing by $ e.g. "Variable contains $Variable"
-    project.ext {
-        controlsFxVersion = '8.40.11'
-        guavaVersion = '19.0'
-        jacksonVersion = '2.7.0'
-        jacksonDataTypeVersion = '2.7.4'
-        junitVersion = '4.12'
-        testFxVersion = '4.0.+'
-        monocleVersion = '1.8.0_20'
+    destinationDir = file("${buildDir}/jar/")
+}
 
-        libDir = 'lib'
-    }
-
-    jacocoTestReport {
-        reports {
-            xml.enabled false
-            csv.enabled false
-            html.destination "${buildDir}/jacocoHtml"
-        }
-    }
-
-    dependencies {
-        compile "org.controlsfx:controlsfx:$controlsFxVersion"
-        compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-        compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
-        compile "com.google.guava:guava:$guavaVersion"
-
-        testCompile "junit:junit:$junitVersion"
-        testCompile "org.testfx:testfx-core:$testFxVersion"
-        testCompile "org.testfx:testfx-junit:$testFxVersion"
-        testCompile "org.testfx:testfx-legacy:$testFxVersion", {
-            exclude group: "junit", module: "junit"
-        }
-        testCompile "org.testfx:openjfx-monocle:$monocleVersion"
-    }
-
-    sourceSets {
-        main {
-            java {
-                srcDir 'src/main/java'
-            }
-            resources {
-                srcDir 'src/main/resources'
-            }
-        }
-    }
-
-    shadowJar {
-        archiveName = "addressbook.jar"
-
-        manifest {
-            attributes "Main-Class": "seedu.address.MainApp"
-        }
-
-        destinationDir = file("${buildDir}/jar/")
-    }
-
-    checkstyle {
-        toolVersion = '7.1'
-    }
+checkstyle {
+    toolVersion = '7.1'
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,6 @@ checkstyle {
     toolVersion = '7.1'
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.12'
-}
-
 task coverage(type: JacocoReport) {
     sourceDirectories = files(allprojects.sourceSets.main.allSource.srcDirs)
     classDirectories =  files(allprojects.sourceSets.main.output)

--- a/build.gradle
+++ b/build.gradle
@@ -23,20 +23,6 @@ repositories {
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-// This part is similar to global variables
-// Access them by using double-quoted strings (GStrings) and referencing by $ e.g. "Variable contains $Variable"
-project.ext {
-    controlsFxVersion = '8.40.11'
-    guavaVersion = '19.0'
-    jacksonVersion = '2.7.0'
-    jacksonDataTypeVersion = '2.7.4'
-    junitVersion = '4.12'
-    testFxVersion = '4.0.+'
-    monocleVersion = '1.8.0_20'
-
-    libDir = 'lib'
-}
-
 jacocoTestReport {
     reports {
         xml.enabled false
@@ -46,18 +32,18 @@ jacocoTestReport {
 }
 
 dependencies {
-    compile "org.controlsfx:controlsfx:$controlsFxVersion"
-    compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
-    compile "com.google.guava:guava:$guavaVersion"
+    compile 'org.controlsfx:controlsfx:8.40.11'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
+    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.7.4'
+    compile 'com.google.guava:guava:19.0'
 
-    testCompile "junit:junit:$junitVersion"
-    testCompile "org.testfx:testfx-core:$testFxVersion"
-    testCompile "org.testfx:testfx-junit:$testFxVersion"
-    testCompile "org.testfx:testfx-legacy:$testFxVersion", {
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.testfx:testfx-core:4.0.+'
+    testCompile 'org.testfx:testfx-junit:4.0.+'
+    testCompile 'org.testfx:testfx-legacy:4.0.+', {
         exclude group: "junit", module: "junit"
     }
-    testCompile "org.testfx:openjfx-monocle:$monocleVersion"
+    testCompile 'org.testfx:openjfx-monocle:1.8.0_20'
 }
 
 shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -22,13 +22,11 @@ repositories {
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
-
-jacocoTestReport {
-    reports {
-        xml.enabled false
-        csv.enabled false
-        html.destination "${buildDir}/jacocoHtml"
-    }
+ext {
+    if (!has('headless'))
+        headless = 'false'
+    if (!has('guiTests'))
+        guiTests = 'true'
 }
 
 dependencies {
@@ -60,80 +58,34 @@ checkstyle {
     toolVersion = '7.1'
 }
 
-task coverage(type: JacocoReport) {
-    sourceDirectories = files(allprojects.sourceSets.main.allSource.srcDirs)
-    classDirectories =  files(allprojects.sourceSets.main.output)
-    executionData = files(allprojects.jacocoTestReport.executionData)
-    afterEvaluate {
-        classDirectories = files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: ['**/*.jar'])
-        })
-    }
-    reports {
-        html.enabled = true
-        xml.enabled = true
-    }
-}
+test {
+    forkEvery = 1
+    systemProperty 'testfx.setup.timeout', '60000'
+    testLogging.exceptionFormat = 'full'
 
-coveralls {
-    sourceDirs = allprojects.sourceSets.main.allSource.srcDirs.flatten()
-    jacocoReportPath = "${buildDir}/reports/jacoco/coverage/coverage.xml"
-}
-
-tasks.coveralls {
-    dependsOn coverage
-    onlyIf { System.env.'CI' }
-}
-
-class AddressBookTest extends Test {
-    public AddressBookTest() {
-        forkEvery = 1
-        systemProperty 'testfx.setup.timeout', '60000'
-    }
-
-    public void setHeadless() {
-        systemProperty 'java.awt.robot', 'true'
-        systemProperty 'testfx.robot', 'glass'
-        systemProperty 'testfx.headless', 'true'
-        systemProperty 'prism.order', 'sw'
-        systemProperty 'prism.text', 't2k'
-    }
-}
-
-task guiTests(type: AddressBookTest) {
-    include 'guitests/**'
-
-    jacoco {
-        destinationFile = new File("${buildDir}/jacoco/test.exec")
-    }
-}
-
-
-task nonGuiTests(type: AddressBookTest) {
     include 'seedu/address/**'
+    if (guiTests == 'true')
+        include 'guitests/**'
 
-    jacoco {
-        destinationFile = new File("${buildDir}/jacoco/test.exec")
+    beforeTest { descriptor ->
+        if (headless == 'true') {
+            systemProperty 'java.awt.robot', 'true'
+            systemProperty 'testfx.robot', 'glass'
+            systemProperty 'testfx.headless', 'true'
+            systemProperty 'prism.order', 'sw'
+            systemProperty 'prism.text', 't2k'
+        }
     }
 }
 
-// Test mode depends on whether headless task has been run
-task allTests(type: AddressBookTest) {
-    jacoco {
-        destinationFile = new File("${buildDir}/jacoco/test.exec")
+jacocoTestReport {
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
     }
 }
 
-task headless << {
-    println "Setting headless mode properties."
-    guiTests.setHeadless()
-    nonGuiTests.setHeadless()
-    allTests.setHeadless()
-}
+tasks.coveralls.dependsOn jacocoTestReport
 
-// Makes sure that headless properties are set before running tests
-nonGuiTests.mustRunAfter headless
-guiTests.mustRunAfter headless
-allTests.mustRunAfter headless
-
-defaultTasks 'clean', 'headless', 'allTests', 'coverage'
+defaultTasks 'build'

--- a/docs/UsingGradle.md
+++ b/docs/UsingGradle.md
@@ -47,6 +47,14 @@ If we package only our own class files into the JAR file, it will not work prope
   Therefore, we package all dependencies into a single JAR files, creating what is also known as a _fat_ JAR file. 
   To create a fat JAR fil, we use the Gradle plugin [shadow jar](https://github.com/johnrengelman/shadow).
 
+## Running the Application
+
+* **`run`** <br>
+  Builds and runs the application.
+
+* **`runShadow`** <br>
+  Builds the shadow JAR, and then runs it.
+
 ## Running Tests
 
 The following project properties control test execution:

--- a/docs/UsingGradle.md
+++ b/docs/UsingGradle.md
@@ -49,24 +49,18 @@ If we package only our own class files into the JAR file, it will not work prope
 
 ## Running Tests
 
-* **`allTests`**<br>
-  Runs all tests.
+The following project properties control test execution:
 
-* **`guiTests`**<br>
-  Runs all tests in the `guitests` package
-  
-* **`nonGuiTests`**<br>
-  Runs all non-GUI tests in the `seedu.address` package
-  
-* **`headless`**<br>
-  Sets the test mode as _headless_. 
-  The mode is effective for that Gradle run only so it should be combined with other test tasks.
-  
+* `headless` -- Run tests in headless mode (default: `false`)
+
+* `guiTests` -- Run GUI tests (default: `true`)
+
 Here are some examples:
 
-* `./gradlew headless allTests` -- Runs all tests in headless mode
-* `./gradlew clean nonGuiTests` -- Cleans the project and runs non-GUI tests
+* `./gradlew -Pheadless=true test` -- Runs all tests in headless mode.
 
+* `./gradlew -PguiTests=false clean test` -- Clean the project and runs only
+  non-GUI tests.
 
 ## Updating Dependencies
 


### PR DESCRIPTION
The `build.gradle` file has been vastly simplified and should now be easier to grok.
- [1/8] [build.gradle: Remove unused 'idea' plugin](https://github.com/CS2103AUG2016-T11-C4/main/pull/3/commits/fbc06de3bb8147ff3558ed11c908f2eee7be85c2)
- [2/8] [build.gradle: fix whitespace errors](https://github.com/CS2103AUG2016-T11-C4/main/pull/3/commits/7777cd1b578ccce71af09e325bbfe942b27747bf)
- [3/8] [build.gradle: Remove allprojects block](https://github.com/CS2103AUG2016-T11-C4/main/pull/3/commits/9faf44f2d1bf8ad2ed1562484c1a32a55779e2df)
- [4/8] [build.gradle: Remove 'wrapper' task](https://github.com/CS2103AUG2016-T11-C4/main/pull/3/commits/f1e57a8e2773ccbb9e297c10797d2a717b8d9f63)
- [5/8] [build.gradle: remove project.ext block](https://github.com/CS2103AUG2016-T11-C4/main/pull/3/commits/3362bc30101b6e2dfb750e188500bdbe71f11306)
- [6/8] [build.gradle: merge the various tests tasks into a single 'test' task](https://github.com/CS2103AUG2016-T11-C4/main/pull/3/commits/b7c9f5bb528eeee19c3dff25ef1c57af00ea376d)
- [7/8] [build.gradle: Add 'run' and 'runShadow' tasks](https://github.com/CS2103AUG2016-T11-C4/main/pull/3/commits/4e389c465ab97a30238c85848a6ac98537405fea)
- [8/8] [build.gradle: set test.forkEvery to 100](https://github.com/CS2103AUG2016-T11-C4/main/pull/3/commits/0764fb10466e92f21e33a544e75a9b2650c493f3)
