### PR TITLE
logic: implement date and time parsers

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DateParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateParser.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.parser;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+
+import com.google.common.base.Optional;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
+/**
+ * A parser for dates in day/month/year format.
+ */
+public class DateParser {
+
+    private final LocalDate referenceDate;
+
+    private final DateTimeFormatter dateFormatter;
+
+    public DateParser(LocalDate referenceDate) {
+        this.referenceDate = referenceDate;
+        dateFormatter = new DateTimeFormatterBuilder()
+                .appendPattern("d[/M[/uuuu]]")
+                .parseDefaulting(ChronoField.MONTH_OF_YEAR, this.referenceDate.getMonthValue())
+                .parseDefaulting(ChronoField.YEAR, this.referenceDate.getYear())
+                .toFormatter();
+    }
+
+    public LocalDate getReferenceDate() {
+        return referenceDate;
+    }
+
+    public LocalDate parse(String str) throws IllegalValueException {
+        final Optional<LocalDate> nameDate = parseAsName(str.trim());
+        if (nameDate.isPresent()) {
+            return nameDate.get();
+        }
+        try {
+            return LocalDate.parse(str.trim(), dateFormatter);
+        } catch (DateTimeParseException e) {
+            throw new IllegalValueException(e.toString());
+        }
+    }
+
+    private Optional<LocalDate> parseAsName(String name) {
+        switch (name) {
+        case "tdy": // today
+            return Optional.of(referenceDate);
+        case "tmr": // tomorrow
+            return Optional.of(referenceDate.plusDays(1));
+        case "yst": // yesterday
+            return Optional.of(referenceDate.minusDays(1));
+        default:
+            return Optional.absent();
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.parser;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
+/**
+ * A date and time parser. See {@link DateParser} and {@link TimeParser}.
+ */
+public class DateTimeParser {
+
+    private final DateParser dateParser;
+
+    private final TimeParser timeParser;
+
+    public DateTimeParser() {
+        this(LocalDateTime.now());
+    }
+
+    public DateTimeParser(LocalDateTime referenceDateTime) {
+        assert referenceDateTime != null;
+        dateParser = new DateParser(referenceDateTime.toLocalDate());
+        timeParser = new TimeParser(referenceDateTime.toLocalTime());
+    }
+
+    public LocalDateTime getReferenceDateTime() {
+        return LocalDateTime.of(dateParser.getReferenceDate(), timeParser.getReferenceTime());
+    }
+
+    public LocalDate parseDate(String str) throws IllegalValueException {
+        return dateParser.parse(str);
+    }
+
+    public LocalTime parseTime(String str) throws IllegalValueException {
+        return timeParser.parse(str);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/TimeParser.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.parser;
+
+import java.time.LocalTime;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
+/**
+ * A parser for 12-hour clock times.
+ */
+public class TimeParser {
+
+    private static final Pattern PATTERN_TIME = Pattern.compile("(?<hour>\\d{1,2})"
+            + "(?:[.:](?<minute>\\d{2}))?(?<ampm>am|pm)");
+
+    private final LocalTime referenceTime;
+
+    public TimeParser(LocalTime referenceTime) {
+        this.referenceTime = referenceTime;
+    }
+
+    public LocalTime getReferenceTime() {
+        return referenceTime;
+    }
+
+    public LocalTime parse(String str) throws IllegalValueException {
+        final Matcher matcher = PATTERN_TIME.matcher(str.trim());
+        if (!matcher.matches()) {
+            throw new IllegalValueException("invalid time format");
+        }
+
+        int hour = Integer.parseInt(matcher.group("hour"));
+        if (hour > 12) {
+            throw new IllegalValueException("invalid hour: " + hour);
+        } else if (hour == 12) {
+            hour = 0;
+        }
+
+        final int minute = matcher.group("minute") != null ? Integer.parseInt(matcher.group("minute")) : 0;
+        if (minute >= 60) {
+            throw new IllegalValueException("invalid minute: " + minute);
+        }
+
+        final boolean isPM = matcher.group("ampm").equals("pm");
+        return LocalTime.of(hour + (isPM ? 12 : 0), minute);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/DateParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateParserTest.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.parser;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.LocalDate;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
+public class DateParserTest {
+
+    private static final LocalDate TEST_DATE = LocalDate.of(2015, 3, 14);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private DateParser parser;
+
+    @Before
+    public void setupParser() {
+        parser = new DateParser(TEST_DATE);
+    }
+
+    @Test
+    public void constructor() {
+        assertEquals(TEST_DATE, parser.getReferenceDate());
+    }
+
+    @Test
+    public void parse() throws Exception {
+        assertParse("tdy", TEST_DATE);
+        assertParse("tmr", TEST_DATE.plusDays(1));
+        assertParse("yst", TEST_DATE.minusDays(1));
+        assertParse(" 1 ", LocalDate.of(2015, 3, 1));
+        assertParse("1/2", LocalDate.of(2015, 2, 1));
+        assertParse("1/2/2014", LocalDate.of(2014, 2, 1));
+        assertParseFail("0/1/2016"); // No such day
+        assertParseFail("1/0/2015"); // No such month
+        assertParseFail("1/13/2015"); // No such month
+        assertParse("31/12/2014", LocalDate.of(2014, 12, 31)); // December has 31 days
+        assertParseFail("31/9/2016"); // September only has 30 days
+        assertParse("29/2/2016", LocalDate.of(2016, 2, 29)); // A leap year
+        assertParseFail("29/2/2015"); // Not a leap year
+        assertParseFail("1/2/14"); // We don't support 2-digit years
+        assertParseFail("not a date at all");
+    }
+
+    private void assertParse(String str, LocalDate expected) throws Exception {
+        final LocalDate actual = parser.parse(str);
+        assertEquals(expected, actual);
+    }
+
+    private void assertParseFail(String str) throws Exception {
+        thrown.expect(IllegalValueException.class);
+        parser.parse(str);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/TimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TimeParserTest.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.LocalTime;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
+public class TimeParserTest {
+
+    private static final LocalTime TEST_TIME = LocalTime.of(3, 14);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private TimeParser parser;
+
+    @Before
+    public void setupParser() {
+        parser = new TimeParser(TEST_TIME);
+    }
+
+    @Test
+    public void constructor() {
+        assertEquals(TEST_TIME, parser.getReferenceTime());
+    }
+
+    @Test
+    public void parse() throws Exception {
+        assertParse("  4am  ", LocalTime.of(4, 0));
+        assertParse("1.23pm", LocalTime.of(13, 23));
+        assertParse("2:45am", LocalTime.of(2, 45));
+        assertParse("12am", LocalTime.of(0, 0));
+        assertParse("12pm", LocalTime.of(12, 0));
+        assertParseFail("13am");
+        assertParseFail("4:99am");
+        assertParseFail("5:am");
+        assertParseFail("not a time at all");
+    }
+
+    private void assertParse(String str, LocalTime expected) throws Exception {
+        final LocalTime actual = parser.parse(str);
+        assertEquals(expected, actual);
+    }
+
+    private void assertParseFail(String str) throws Exception {
+        thrown.expect(IllegalValueException.class);
+        parser.parse(str);
+    }
+
+}


### PR DESCRIPTION
This PR implements a `DateTimeParser` that is able to parse dates and times as defined by the user guide.
- [1/3] [parser: implement DateParser](https://github.com/CS2103AUG2016-T11-C4/main/pull/47/commits/2715d26d0d900beacf17e3adce7cc6a903d3cf4a)
- [2/3] [parser: implement TimeParser](https://github.com/CS2103AUG2016-T11-C4/main/pull/47/commits/d32751ac4f98a9b30cf4355b06c8b8ad45d555bb)
- [3/3] [parser: implement DateTimeParser](https://github.com/CS2103AUG2016-T11-C4/main/pull/47/commits/f133879a8a77875957ddcb3f3de27876b712c2c7)
