### PR TITLE
JsonTaskBookStorage::saveTaskBook(): create parent dirs if missing

### DIFF
--- a/src/main/java/seedu/address/storage/JsonTaskBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonTaskBookStorage.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.FileUtil;
 import seedu.address.model.ReadOnlyTaskBook;
 import seedu.address.model.TaskBook;
 
@@ -75,6 +76,7 @@ public class JsonTaskBookStorage implements TaskBookStorage {
     public void saveTaskBook(ReadOnlyTaskBook taskBook, String filePath) throws IOException {
         assert !CollectionUtil.isAnyNull(taskBook, filePath);
         final File file = new File(filePath);
+        FileUtil.createIfMissing(file);
         objectMapper.writeValue(file, taskBook);
     }
 


### PR DESCRIPTION
JsonTaskBookStorage::saveTaskBook() does not attempt to create the
parent directories of the target save file, and thus will fail if the
parent directories do not exist.

For example, by default the target save file is 'data/taskbook.json'.
However, if the 'data' directory does not exist, then
JsonTaskBookStorage::saveTaskBook() will fail with a
java.io.FileNotFoundException.

Fix this by calling FileUtil::createIfMissing() just before we attempt
to write to the target save file. FileUtil::createIfMissing() will take
care of creating the parent directories of the target save file if they
do not exist, thus fixing this bug.
