### PR TITLE
docs: setup markdown to pdf conversion for UserGuide/DeveloperGuide

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,51 @@ jacocoTestReport {
 
 tasks.coveralls.dependsOn jacocoTestReport
 
+class PandocTask extends DefaultTask {
+
+    @InputFiles
+    List<File> inputFiles
+
+    @InputDirectory
+    File dataDir = project.file('pandoc')
+
+    @Input
+    File workDir
+
+    @Input
+    List<String> cmdArgs
+
+    @InputFiles
+    List<File> filters = []
+
+    @OutputFile
+    File outputFile
+
+    @TaskAction
+    def generate() {
+        project.exec {
+            workingDir workDir
+            commandLine(['pandoc', '--self-contained', '-s',
+                         "--data-dir=${dataDir}",
+                         '-o', outputFile]
+                        + filters.collect({ "--filter=${it}" })
+                        + cmdArgs
+                        + inputFiles.collect({it.toString()}))
+        }
+    }
+}
+
+task(pandoc, type: PandocTask) {
+    workDir = project.file('docs')
+    inputFiles = [project.file('docs/UserGuide.md'),
+                               project.file('docs/DeveloperGuide.md')]
+    cmdArgs = ['-f', 'markdown_github-hard_line_breaks+definition_lists+yaml_metadata_block+raw_tex',
+               '-t', 'latex',
+               '--latex-engine', 'xelatex']
+    outputFile = new File(project.docsDir, 'manual.pdf')
+    filters = []
+}
+
 artifacts {
     archives shadowJar
 }

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,8 @@ task(pandoc, type: PandocTask) {
     outputFile = new File(project.docsDir, 'manual.pdf')
     filters = [project.file('pandoc/githubonly.py'),
                project.file('pandoc/latexonly.py'),
-               project.file('pandoc/anchorheadings.py')]
+               project.file('pandoc/anchorheadings.py'),
+               project.file('pandoc/appendixrename.py')]
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ task(pandoc, type: PandocTask) {
                '-t', 'latex',
                '--latex-engine', 'xelatex']
     outputFile = new File(project.docsDir, 'manual.pdf')
-    filters = [project.file('pandoc/githubonly.py')]
+    filters = [project.file('pandoc/githubonly.py'), project.file('pandoc/latexonly.py')]
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,9 @@ task(pandoc, type: PandocTask) {
                '-t', 'latex',
                '--latex-engine', 'xelatex']
     outputFile = new File(project.docsDir, 'manual.pdf')
-    filters = [project.file('pandoc/githubonly.py'), project.file('pandoc/latexonly.py')]
+    filters = [project.file('pandoc/githubonly.py'),
+               project.file('pandoc/latexonly.py'),
+               project.file('pandoc/anchorheadings.py')]
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ task(pandoc, type: PandocTask) {
                '-t', 'latex',
                '--latex-engine', 'xelatex']
     outputFile = new File(project.docsDir, 'manual.pdf')
-    filters = []
+    filters = [project.file('pandoc/githubonly.py')]
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,8 @@ task(pandoc, type: PandocTask) {
     filters = [project.file('pandoc/githubonly.py'),
                project.file('pandoc/latexonly.py'),
                project.file('pandoc/anchorheadings.py'),
-               project.file('pandoc/appendixrename.py')]
+               project.file('pandoc/appendixrename.py'),
+               project.file('pandoc/latexfigure.py')]
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,8 @@ task(pandoc, type: PandocTask) {
                                project.file('docs/DeveloperGuide.md')]
     cmdArgs = ['-f', 'markdown_github-hard_line_breaks+definition_lists+yaml_metadata_block+raw_tex',
                '-t', 'latex',
-               '--latex-engine', 'xelatex']
+               '--latex-engine', 'xelatex',
+               '--listings']
     outputFile = new File(project.docsDir, 'manual.pdf')
     filters = [project.file('pandoc/githubonly.py'),
                project.file('pandoc/latexonly.py'),

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,8 @@ task(pandoc, type: PandocTask) {
                project.file('pandoc/latexonly.py'),
                project.file('pandoc/anchorheadings.py'),
                project.file('pandoc/appendixrename.py'),
-               project.file('pandoc/latexfigure.py')]
+               project.file('pandoc/latexfigure.py'),
+               project.file('pandoc/latexblockquote.py')]
 }
 
 artifacts {

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1,5 +1,7 @@
 # Developer Guide
 
+<!-- BEGIN GITHUB -->
+
 * [Setting Up](#setting-up)
 * [Design](#design)
 * [Implementation](#implementation)
@@ -9,6 +11,8 @@
 * [Appendix C: Non Functional Requirements](#appendix-c-non-functional-requirements)
 * [Appendix D: Glossary](#appendix-d-glossary)
 * [Appendix E: Product Survey](#appendix-e-product-survey)
+
+<!-- END GITHUB -->
 
 ## Setting up
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -791,11 +791,40 @@ a new group activity.
   <dd>Task that has an end datetime only.</dd>
 
   <dt>Floating task</dt>
-  <dd>A task that has neither a start datetime not end datetime./dd>
+  <dd>A task that has neither a start datetime not end datetime.</dd>
 
   <dt>Time slot</dt>
   <dd>A time slot is referring to a period of time</dd>
 </dl>
+
+<!-- BEGIN LATEX
+
+\begin{description}
+
+\item[Task book] \hfill \\
+    The database where events, deadlines and floating tasks are stored.
+
+\item[Datetime] \hfill \\
+    Date and time
+
+\item[Task] \hfill \\
+    A unit of information in the task book database. Each task has a name.
+
+\item[Event] \hfill \\
+    Task that has a start datetime and end datetime.
+
+\item[Deadline] \hfill \\
+    Task that has an end datetime only.
+
+\item[Floating task] \hfill \\
+    A task that has neither a start datetime nor end datetime.
+
+\item[Time slot] \hfill \\
+    A time slot is referring to a period of time.
+
+\end{description}
+
+END LATEX -->
 
 # Appendix E: Product Survey
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -290,12 +290,16 @@ We have two types of tests:
 * To run all tests, execute the following in the project work
   directory:
 
-      ./gradle test
+    ```
+    ./gradle test
+    ```
 
 * To only run non-GUI tests, execute the following in the project work
   directory:
 
-      ./gradle -PguiTests=false test
+    ```
+    ./gradle -PguiTests=false test
+    ```
 
 ### Troubleshooting tests
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -834,7 +834,11 @@ END LATEX -->
 
 ## Todo.txt
 
+<!-- BEGIN GITHUB -->
+
 Full product survey [here](productsurveys/todo.txt.md)
+
+<!-- END GITHUB -->
 
 Jim's Requirement                                        | Todo.txt Support
 :------------------------------------------------------- | ---------------
@@ -879,7 +883,11 @@ operations are done without user confirmation.
 
 ## Todoist
 
+<!-- BEGIN GITHUB -->
+
 Full product survey [here](productsurveys/Todoist.md)
+
+<!-- END GITHUB -->
 
 Jim’s Requirement                                        | Todoist support
 :------------------------------------------------------- | ---------------
@@ -928,7 +936,11 @@ perform wrongly.
 
 ## Wunderlist
 
+<!-- BEGIN GITHUB -->
+
 Full product survey [here](productsurveys/Wunderlist.md)
+
+<!-- END GITHUB -->
 
 Wunderlist in brief: Written in Javascript and PHP, Wunderlist is a task
 manager application with a simple, intuitive,and beautiful User Interface that
@@ -956,7 +968,11 @@ So, how well does Wunderlist satisfy Jim's requirements?
 
 ## Google Calendar
 
+<!-- BEGIN GITHUB -->
+
 Full product survey [here](https://docs.google.com/document/d/1ELun1gQUiVAxC6it-16jikFRwAePTXS5Xri7GdhUnL8/edit?usp=sharing)
+
+<!-- END GITHUB -->
 
 Jim's Requirement                                                | Google Calendar
 :--------------------------------------------------------------- | ---------------

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -20,7 +20,7 @@
 
 1. **JDK `1.8.0_60`**  or later<br>
 
-    > Having any Java 8 version is not enough.
+    > Note: Having any Java 8 version is not enough.
       This app will not work with earlier versions of Java 8.
 
 2. **Eclipse** IDE

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -331,8 +331,8 @@ User categories:
   (keystrokes, mouseclicks, confirmations) as possible.
 * Group user -- User that has other people working on the same task
 
-Priority | As a ... | I want to ... | So that I can...
--------- | :------- | :------------ | :---------------
+Priority | As a ... | I want to ...             | So that I can...
+-------- | :------- | :------------------------ | :---------------------------
 `* * *`  | New user | See the manual | refer to manual when I forget how to use the App
 `* * *`  | User | Add an event to the task manager | keep track of it and be notified when it is approaching.
 `* * *`  | User | Add a deadline to the task manager | keep track of it and be notified when it is approaching.
@@ -803,8 +803,8 @@ a new group activity.
 
 Full product survey [here](productsurveys/todo.txt.md)
 
-Jim's Requirement | Todo.txt Support
-:---------------- | ----------------
+Jim's Requirement                                        | Todo.txt Support
+:------------------------------------------------------- | ---------------
 Summoned quickly from anywhere | No
 Keyboard-oriented. Jim can type commands in "one shot" | Yes
 Works offline | Yes
@@ -848,8 +848,8 @@ operations are done without user confirmation.
 
 Full product survey [here](productsurveys/Todoist.md)
 
-Jim’s Requirement | Todoist support
-:---------------- | ------------------
+Jim’s Requirement                                        | Todoist support
+:------------------------------------------------------- | ---------------
 Summoned quickly from anywhere | No
 Keyboard-oriented. Jim can type commands in “one shot”. | No
 Keyboard-oriented. Jim can use keyboard shortcut to increase efficiency. | Yes
@@ -906,8 +906,8 @@ collaborating features are accessible.
 
 So, how well does Wunderlist satisfy Jim's requirements?
 
-| Jim's Requirement | Wunderlist support |
-| --- | --- |
+| Jim's Requirement                                        | Wunderlist support |
+| :------------------------------------------------------- | ------------------ |
 | Summoned quickly from anywhere | No |
 | Keyboard-oriented. Jim can type commands in "one shot". | Partially |
 | Works offline | Yes |
@@ -925,8 +925,8 @@ So, how well does Wunderlist satisfy Jim's requirements?
 
 Full product survey [here](https://docs.google.com/document/d/1ELun1gQUiVAxC6it-16jikFRwAePTXS5Xri7GdhUnL8/edit?usp=sharing)
 
-Jim's Requirement | Google Calendar
-:---------------- | ----------------
+Jim's Requirement                                                | Google Calendar
+:--------------------------------------------------------------- | ---------------
 Summoned quickly from anywhere | Yes
 Keyboard-oriented. Jim can type commands in "one shot" | Yes
 Works offline | Partially

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -81,7 +81,10 @@
 
 ### Architecture
 
-![Architecture Diagram](images/devguide/architecture.png)
+<figure>
+<img src="images/devguide/architecture.png">
+<figcaption><div align="center">Figure 2.1: Architecture diagram of TaskTracker</div></figcaption>
+</figure>
 
 The **_Architecture Diagram_** given above explains the high-level design of
 the App.
@@ -133,7 +136,10 @@ The sections below give more details of each component.
 
 ### Model component
 
-![Model component class diagram](images/devguide/comp-model.png)
+<figure>
+<img src="images/devguide/comp-model.png">
+<figcaption><div align="center">Figure 2.2: Model component class diagram</div></figcaption>
+</figure>
 
 The `Model` component:
 
@@ -147,7 +153,10 @@ The `Model` component:
 
 ### Storage component
 
-![Storage component class diagram](images/devguide/comp-storage.png)
+<figure>
+<img src="images/devguide/comp-storage.png">
+<figcaption><div align="center">Figure 2.3: Storage component class diagram</div></figcaption>
+</figure>
 
 The `Storage` component:
 
@@ -157,7 +166,10 @@ The `Storage` component:
 
 ### Logic component
 
-![Logic component class diagram](images/devguide/comp-logic.png)
+<figure>
+<img src="images/devguide/comp-logic.png">
+<figcaption><div align="center">Figure 2.4: Logic component class diagram</div></figcaption>
+</figure>
 
 The `Logic` component:
 
@@ -179,11 +191,17 @@ It accomplishes its parsing and execution of user commands in a few steps:
 Given below is the Sequence Diagram for interactions within the `Logic`
 component for the `execute("delete 1")` API call.
 
-![Sequence diagram for event deletion](images/devguide/seq-deleteevent.png)
+<figure>
+<img src="images/devguide/seq-deleteevent.png">
+<figcaption><div align="center">Figure 2.5: Sequence diagram for event deletion</div></figcaption>
+</figure>
 
 ### Ui component
 
-![Ui component class diagram](images/devguide/comp-ui.png)
+<figure>
+<img src="images/devguide/comp-ui.png">
+<figcaption><div align="center">Figure 2.6: Ui component class diagram</div></figcaption>
+</figure>
 
 The `Ui` component,
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -279,8 +279,8 @@ We have two types of tests:
 
 ### Testing with Eclipse
 
-* To run all tests, right-click on the `src/test/java` folder and choose `Run
-  as` > `JUnit Test`
+* To run all tests, right-click on the `src/test/java` folder and choose
+  `Run as` > `JUnit Test`
 
 * To run a subset of tests, you can right-click on a test package, test class,
   or a test and choose to run as a JUnit test.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -309,7 +309,11 @@ AssertionError is expected**
   [here](http://stackoverflow.com/questions/2522897/eclipse-junit-ea-vm-option).
   Delete run configurations created when you ran tests earlier.
 
-## Appendix A: User Stories
+<!-- BEGIN LATEX
+\appendix
+END LATEX -->
+
+# Appendix A: User Stories
 
 Priorities:
 
@@ -352,13 +356,13 @@ Priority | As a ... | I want to ... | So that I can...
 `*`      | Group user | Option to categorize my task as a "Group activity" and automatically send notifications (through mail or other social networking platforms) to all other users who are in my team, whenever I make any changes to our work schedule for the group activity; and send them reminders about upcoming deadlines for the tasks. Every time I add a new task, I should have also an option to either include it to an existing group activity or add it to a new group activity. | Improve my work efficiency, and make sure everyone in my team are aware of the work schedule of our project.
 `* `     | User who needs to be reminded of the task before the deadline date. | Set reminders at customized times before the deadline. | Have enough time to complete the task before deadline, even if I forgot to do it.
 
-## Appendix B: Use Cases
+# Appendix B: Use Cases
 
 **Software System**: TaskTracker
 
 **Actor**: User
 
-### Use case: Add an event
+## Use case: Add an event
 
 **MSS**
 
@@ -400,7 +404,7 @@ Priority | As a ... | I want to ... | So that I can...
 
 > Use case resumes from step 2.
 
-### Use case: Add a deadline
+## Use case: Add a deadline
 
 **MSS**
 
@@ -432,7 +436,7 @@ Priority | As a ... | I want to ... | So that I can...
 
 > Use case resumes from step 2.
 
-### Use case: Add a floating task
+## Use case: Add a floating task
 
 **MSS**
 
@@ -459,7 +463,7 @@ Priority | As a ... | I want to ... | So that I can...
 
 > Use case resumes from step 2.
 
-### Use case: View all floating tasks
+## Use case: View all floating tasks
 
 **MSS**
 
@@ -478,7 +482,7 @@ Priority | As a ... | I want to ... | So that I can...
 
 > Use case ends.
 
-### Use case: Revise the due time of a deadline task
+## Use case: Revise the due time of a deadline task
 
 **MSS**
 
@@ -510,7 +514,7 @@ Priority | As a ... | I want to ... | So that I can...
 
 > Use case resumes from step 2.
 
-### Use case: Revise the time of an event
+## Use case: Revise the time of an event
 
 **MSS**
 
@@ -557,7 +561,7 @@ Priority | As a ... | I want to ... | So that I can...
 
 > Use case ends.
 
-### Use case: mark a floating task/deadline as finished
+## Use case: mark a floating task/deadline as finished
 
 **MSS**
 
@@ -574,7 +578,7 @@ Priority | As a ... | I want to ... | So that I can...
 
 > Use case ends.
 
-### Use case: Generate a list of empty time slots
+## Use case: Generate a list of empty time slots
 
 **MSS**
 
@@ -605,7 +609,7 @@ Priority | As a ... | I want to ... | So that I can...
 
 > Use case ends.
 
-### Use case: Add priority tags
+## Use case: Add priority tags
 
 **MSS**
 
@@ -634,7 +638,7 @@ Priority | As a ... | I want to ... | So that I can...
 
 > Use case ends.
 
-### Use case: Add new event under a specific "group activity"
+## Use case: Add new event under a specific "group activity"
 
 **MSS**
 
@@ -667,7 +671,7 @@ a new group activity.
 
 > Use case ends.
 
-### Use case: Add event description
+## Use case: Add event description
 
 **MSS**
 
@@ -680,7 +684,7 @@ a new group activity.
 
    User case ends.
 
-### Use case: Set reminders
+## Use case: Set reminders
 
 **MSS**
 
@@ -701,7 +705,7 @@ a new group activity.
 
 > User case ends.
 
-### See the manual
+## See the manual
 
 **Use case: see the manual**
 
@@ -713,7 +717,7 @@ a new group activity.
 
    Use case ends.
 
-### Search the manual
+## Search the manual
 
 **Use case: search the manual**
 
@@ -733,7 +737,7 @@ a new group activity.
 
 > Use case ends
 
-### Undo an action
+## Undo an action
 
 **User case: Undo an action, such as restoring a deleted a task**
 
@@ -754,7 +758,7 @@ a new group activity.
 
 > User Case ends.
 
-## Appendix C: Non Functional Requirements
+# Appendix C: Non Functional Requirements
 
 1. Should work on any mainstream OS as long as it has Java `1.8.0_60` or higher
    installed.
@@ -768,7 +772,7 @@ a new group activity.
 
 5. For a full list of constrains, see the handbook at http://www.comp.nus.edu.sg/~cs2103/AY1617S1/contents/handbook.html#handbook-project-constraints  
 
-## Appendix D: Glossary
+# Appendix D: Glossary
 
 <dl>
   <dt>Task book</dt>
@@ -793,9 +797,9 @@ a new group activity.
   <dd>A time slot is referring to a period of time</dd>
 </dl>
 
-## Appendix E: Product Survey
+# Appendix E: Product Survey
 
-### Todo.txt
+## Todo.txt
 
 Full product survey [here](productsurveys/todo.txt.md)
 
@@ -840,7 +844,7 @@ Finally, it has no support for undoing operations. While this is alleviated
 somewhat as it asks for confirmation before deleting tasks, all other
 operations are done without user confirmation.
 
-### Todoist
+## Todoist
 
 Full product survey [here](productsurveys/Todoist.md)
 
@@ -889,7 +893,7 @@ floating task or deadline task in a single window. The second one is the "Undo"
 command, which enables the user to undo the last command immediately when them
 perform wrongly.
 
-### Wunderlist
+## Wunderlist
 
 Full product survey [here](productsurveys/Wunderlist.md)
 
@@ -917,7 +921,7 @@ So, how well does Wunderlist satisfy Jim's requirements?
 | Flexibility in command line format. | No |
 | Undo operations | Tiny |
 
-### Google Calendar
+## Google Calendar
 
 Full product survey [here](https://docs.google.com/document/d/1ELun1gQUiVAxC6it-16jikFRwAePTXS5Xri7GdhUnL8/edit?usp=sharing)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -207,7 +207,7 @@ TaskTracker makes time-management smart and simple for you!
 <a name="qss">**Quick Start Summary**</a>
 
 | Command | Essential Parameters|
-|---------|:----------|
+|---------|:-----------------------------------------------------------------------------|
 |add| `"taskname"` <br> `"deadline task name"` `date` `time` <br> `"event name"` `start date` `start time` `end date` `end time`|
 | edit | `-float` `index` `n-` `p-` <br> `-deadline` `index` `n-` `dd-` `dt-` <br> `-event` `index` `n-` `sd-` `st-` `ed-` `et` `loc-` <br>
 | del | `-float` or `-deadline` or `-event` `index`|
@@ -223,7 +223,7 @@ different type of task: floating task, deadline task, and event, depending on
 the type and number of fields entered when creating the task.
 
 |A/An... | has...|
-|----| :--------:|:------|
+|----| :-------------------------------------|
 |Floating Task | only a task name|
 |Deadline task |  end time and date |
 |Event | start time and date,  end time and date|
@@ -251,8 +251,8 @@ All the time and date fields of the task have to be entered in order to create t
 
 ### <a name="pk">Parameter keywords</a>
 
-|Keyword | Definition|
-|----| :--------:|
+|Keyword | Definition     |
+|----| :------------------|
 |`tdy` | today|
 |`tmr` | tommorow|
 |`yst` | yesteday|
@@ -461,8 +461,8 @@ Delete a useless floating task/event/deadline on TaskTracker.
 
 Edit a floating task to revise its name or priority.
 
-|Field reference | Definition |
-|:----------------:|:-----------:|
+|Field reference | Definition                    |
+|:----------------|:-----------------------------|
 | n- | name |
 | p- | priority |
 
@@ -491,8 +491,8 @@ Edit a floating task to revise its name or priority.
 
 Edit a deadline to revise its name and due date/time.
 
-|Field reference | Definition |
-|:----------------:|:-----------:|
+|Field reference | Definition                        |
+|:----------------|:---------------------------------|
 | n- | name |
 | dd- | due date |
 | dt- | due time |
@@ -518,8 +518,8 @@ Edit a deadline to revise its name and due date/time.
 
 Edit an event to revise its name, starting/ending date/time and location.
 
-|Field reference | Definition |
-|----------------|:-----------|
+|Field reference | Definition                  |
+|----------------|:--------------------------- |
 | n- | name |
 | sd- | start date |
 | st- | start time |
@@ -677,7 +677,7 @@ Exits the program.
 ## Command Summary
 
 Command | Format
------------- | :--------
+------------ | :---------------------------------------------------------------
 Add Floating Task | `add "FLOATING_TASK_NAME" [PRIORITY]`
 Add Event |`add “EVENT_NAME” <STARTING_DATE> <STARTING_TIME> <ENDING_DATE> <ENDING_TIME> [loc-LOCATION]`
 Add Deadline |`add “DEADLINE_NAME” <DATE> <TIME>`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -205,16 +205,6 @@ TaskTracker makes time-management smart and simple for you!
 16. Refer to the [Features](#features) section below for details of each
     command.
 
-<a name="qss">**Quick Start Summary**</a>
-
-| Command | Essential Parameters|
-|---------|:-----------------------------------------------------------------------------|
-|add| `"taskname"` <br> `"deadline task name"` `date` `time` <br> `"event name"` `start date` `start time` `end date` `end time`|
-| edit | `-float` `index` `n-` `p-` <br> `-deadline` `index` `n-` `dd-` `dt-` <br> `-event` `index` `n-` `sd-` `st-` `ed-` `et` `loc-` <br>
-| del | `-float` or `-deadline` or `-event` `index`|
-| fin |`-float` or `-deadline` or `-event` `index`|
-| exit | |
-
 ## Features
 
 ### <a name="dm">Data models</a>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -68,8 +68,8 @@ TaskTracker makes time-management smart and simple for you!
 
 1. Ensure you have Java version `1.8.0_60` or later installed in your computer.
 
-  > Having any Java 8 version is not enough.
-  > This app will not work with earlier versions of Java 8.
+    > Having any Java 8 version is not enough.
+    > This app will not work with earlier versions of Java 8.
 
 2. Download the latest `TaskTracker.jar` from the 'releases' tab.
 
@@ -84,49 +84,50 @@ TaskTracker makes time-management smart and simple for you!
 6. You're good to go! Try adding your first Task. Press Enter to enter a
    command. For floating task, try `add "Learn Task Tracker"`.
 
-   ![alt text](./images/userguide/1.png "command bar")
+    ![alt text](./images/userguide/1.png "command bar")
 
-   Let's do another one, `add "bake potatoes" 2`
+    Let's do another one, `add "bake potatoes" 2`
 
-   ![alt text](./images/userguide/2.png "")
+    ![alt text](./images/userguide/2.png "")
 
-   Notice how bake potatoes is below Learn Task Tracker. That's because bake
-   potatoes is of number 2 priority, while Learn Task Tracker with an undefined
-   priority takes the default highest priority number of 0.
+    Notice how `bake potatoes` is below `Learn Task Tracker`. That's because
+    `bake potatoes` is of number 2 priority, while `Learn Task Tracker` with an
+    undefined priority takes the default highest priority number of 0.
 
 7. Let's add deadline tasks with due date and time.
 
 	* `add "bake cookies" 31/12 3pm`
 
-      bake cookies by 31 December of this year, 3pm. Undeclared year in date
-      field will be taken as the current year.
+        `bake cookies` by 31 December of this year, 3pm. Undeclared year in date
+        field will be taken as the current year.
 
 	* `add "bake cookies" tdy 3pm`
 
-      Bake cookies by today, 3pm.
+        `bake cookies` by today, 3pm.
 
-   ![alt text](./images/userguide/3.png "")
+    ![alt text](./images/userguide/3.png "")
 
 8. Next up, events. An event is a task with a start date, start time, end date
    and end time. Example commands are:
 
 	* `add "CS2103t summer camp" 30/8 1pm 3/1/2017 6pm`
 
-      Event CS2103t summer camp starts on 30 Aug 2016, 1pm, and ends on 3
-      January 2017,6pm.
+        Event `CS2103t summer camp` starts on 30 Aug 2016, 1pm, and ends on 3
+        January 2017,6pm.
 
 	* `add "potato peeling" tdy 3pm to 7pm`
 
-      Event potato peeling starts today 3pm and ends today 7pm.
+        Event `potato peeling` starts today 3pm and ends today 7pm.
 
 	* `add "cupcake festival" tdy 8pm tmr 12pm loc-NUS`
 
-      Event cupcake festival starts today 8pm and ends tomorrow 12 pm at NUS.
+        Event `cupcake festival` starts today 8pm and ends tomorrow 12 pm at
+        NUS.
 
 	* `add "Trick or treat" 31/10 8pm to 9pm`
 
-      Event Trick or treat starts 31 October this year 8pm and ends on the same
-      day, 9pm.
+        Event `Trick or treat` starts 31 October this year 8pm and ends on the
+        same day, 9pm.
 
     ![alttext](./images/userguide/4.png "")
 
@@ -137,15 +138,15 @@ TaskTracker makes time-management smart and simple for you!
 
         del-float 2
 
-    Delete floating task bake potatoes.
+    Delete floating task `bake potatoes`.
 
         del-deadline 1
 
-    Delete deadline task bake cookies.
+    Delete deadline task `bake cookies`.
 
         del-event 4
 
-    Delete Event Trick or treat.
+    Delete Event `Trick or treat`.
 
     ![alttext](./images/userguide/5.png "")
 
@@ -153,53 +154,53 @@ TaskTracker makes time-management smart and simple for you!
 
 	* `edit-deadline 1 dd-29dec dt-2pm`
 
-      The following properties of task are modified: due date, due time.  (`dd`
-      refers to due date, `dt` refers to due time)
+        The following properties of task are modified: due date, due time. (`dd`
+        refers to due date, `dt` refers to due time)
 
 	* `edit-deadline 1 dt-3pm`
 
-      Only due time of bake cookies modified.
+        Only due time of `bake cookies` modified.
 
-      ![alttext](./images/userguide/6.png "")
+    ![alttext](./images/userguide/6.png "")
 
 12. To edit an event, try:
 
 	* `edit-event 2 loc-NUS`
 
-      Location of potato peeling set to NUS.
+        Location of `potato peeling` set to NUS.
 
 	* `edit-event 3 st-3pm sd-12oct et-5pm ed-13oct loc-Yishun`
 
-      All fields modified. (`st` : `starting time`, `sd` : `starting date`,
-      `et` : `ending time`, `ed` : `ending date`)
+        All fields modified. (`st` : `starting time`, `sd` : `starting date`,
+        `et` : `ending time`, `ed` : `ending date`)
 
-      ![alttext](./images/userguide/7.png "")
+        ![alttext](./images/userguide/7.png "")
 
     * `edit-event 2 st-3pm`
 
-      Start time of potato peeling modified.
+        Start time of `potato peeling` modified.
 
-      ![alttext](./images/userguide/8.png "")
+        ![alttext](./images/userguide/8.png "")
 
 13. To edit a floating task, try:
 
 	* `edit-float 1 p-1`
 
-       Floating Task Learn Task Tracker is given a priority of 1.
+        Floating Task `Learn Task Tracker` is given a priority of 1.
 
-       ![alttext](./images/userguide/9.png "")
+        ![alttext](./images/userguide/9.png "")
 
 14. You've finished a task. Congrations! Let's mark a task as finshed.
 
-    * `fin-float 1`
+     * `fin-float 1`
 
-    Floating task Learn Task Tracker is marked as finished.
+        Floating task `Learn Task Tracker` is marked as finished.
 
 15. To exit the program, try:
 
-	* `exit`
+	 * `exit`
 
-      Close the Task-tracker.
+        Close the Task-tracker.
 
 16. Refer to the [Features](#features) section below for details of each
     command.
@@ -264,61 +265,73 @@ Valid input examples:
 
 * dd/mm/yy
 
-      31/12/2016
+    ```
+    31/12/2016
+    ```
 
 * dd/mm
 
-      31/12
+    ```
+    31/12
+    ```
 
-  If the year is not defined, the year is assumed to be the current year. The
-  year this document was last updated was 2016, therefore all examples
-  protraying the current year will read 2016.
+    If the year is not defined, the year is assumed to be the current year. The
+    year this document was last updated was 2016, therefore all examples
+    protraying the current year will read 2016.
 
 * dd
 
-      31
+    ```
+    31
+    ```
 
-  If the month is not defined, the month is assumed to be the current month.
+    If the month is not defined, the month is assumed to be the current month.
 
 * Today
 
-      tdy
+    ```
+    tdy
+    ```
 
-  Means today, the current date as logged by the local machine.
+    Means today, the current date as logged by the local machine.
 
 * Tommorow
 
-      tmr
+    ```
+    tmr
+    ```
 
-  Means tommorow, the day after today as logged by the local machine.
+    Means tommorow, the day after today as logged by the local machine.
 
 * To
 
-      to
+    ```
+    to
+    ```
 
-  This keyword is only applicable for adding an event. `to` can only be
-  entered into an `<END_DATE>` field. `to` would mean the `<END_DATE>` is the
-  same as the `<START_DATE>` for an event. See [example](#to).
+    This keyword is only applicable for adding an event. `to` can only be
+    entered into an `<END_DATE>` field. `to` would mean the `<END_DATE>` is the
+    same as the `<START_DATE>` for an event. See [example](#to).
 
 ### <a name="TimeFormat">Time Format</a>
 
-The 12 hour clock is used. hh:mm am/pm
+The 12 hour clock is used. `hh:mm am/pm`
 
 Valid input examples:
 
-    8:30am
+* `8:30am`
 
-8:30am in the morning
+    8:30am in the morning
 
-	11:45pm
+* `11:45pm`
 
-11:45pm at night
+    11:45pm at night
 
-	8:00pm
+* `8:00pm`
 
-8:00pm at night
+    8:00pm at night
 
-If the minute field is 00, it may be ommitted from the command.
+If the minute field is `00`, it may be ommitted from the command.
 
 ### <a name="help">Viewing help : `help`</a>
 
@@ -377,21 +390,21 @@ Adds a deadline with specific due date and time to TaskTracker.
 
 * `add "CS2103 V1.1" 16/12 2pm`
 
-  To create a deadline task named `CS2103 V1.1` with deadline of 16th December
-  2016, 2pm.
+    To create a deadline task named `CS2103 V1.1` with deadline of 16th
+    December 2016, 2pm.
 
 * `add "spend pizza vouchers" 20/11/2018 2pm`
 
-  To create a deadline task named `spend pizza vouchers` with deadline of 20
-  November 2018, 6pm.
+    To create a deadline task named `spend pizza vouchers` with deadline of 20
+    November 2018, 6pm.
 
 * `add "event proposal" tdy 6pm`
 
-  To create a deadline named `event proposal` with due date today, 6 pm.
+    To create a deadline named `event proposal` with due date today, 6 pm.
 
 * `add "EE2024 homework 1" tmr 6am`
 
-  To create a deadline named `EE2024 homework 1` tommorow, 6 am.
+    To create a deadline named `EE2024 homework 1` tommorow, 6 am.
 
 ### <a name="adde"> Adding an event: `add`</a>
 
@@ -416,18 +429,18 @@ TaskTracker.
 
 * <a name="to">`add "CS2103 week8 lecture" 7oct 2pm to 4pm`</a>
 
-  To create an event `CS2103 week8 lecture` with starting date 7 October 2016,
-  starting time 2pm, ending date 7 Oct 2016, ending time 4pm.
+    To create an event `CS2103 week8 lecture` with starting date 7 October
+    2016, starting time 2pm, ending date 7 Oct 2016, ending time 4pm.
 
 * `add "programming workshop" tdy 10am to 5pm loc-LT15`
 
-  To create an event `programming workshop` that starts today, 10am, and last
-  till 5pm, at LT15.
+    To create an event `programming workshop` that starts today, 10am, and last
+    till 5pm, at LT15.
 
 * `add "sports training camp" 1/12/2016 7pm 10/1/2017 1pm`
 
-  To create an event `sports training camp` with starting date 1 December 2016,
-  starting time 7pm, ending date 10 January 2017 and ending time 1pm.
+    To create an event `sports training camp` with starting date 1 December
+    2016, starting time 7pm, ending date 10 January 2017 and ending time 1pm.
 
 ### <a name="del"> Deleting a floating task/event/deadline: `del`</a>
 
@@ -444,7 +457,7 @@ Delete a useless floating task/event/deadline on TaskTracker.
 
 * `del-event 1`
 
-  Delete the event with the unique index of `1`.
+    Delete the event with the unique index of `1`.
 
 ### Edit a floating task/deadline/event: `edit`
 
@@ -477,15 +490,16 @@ Edit a floating task to revise its name or priority.
 
 * `edit-float 2 p-0`
 
-  Edit flaoting task with unique index of `2`'s priority to 0.
+    Edit floating task with unique index of `2`'s priority to 0.
 
 * `edit-float 2 n-buy stationary`
 
-  Edit floating task with unique index of `2`'s name to `"buy stationary"`.
+    Edit floating task with unique index of `2`'s name to `"buy stationary"`.
 
 * `edit-float 5 n-"go to Nanyang Mart" p-1`
 
-  Edit floating task with unique index of `5`'s name to `"go to Nanyang Mart"` and priority to 1.
+    Edit floating task with unique index of `5`'s name to `"go to Nanyang
+    Mart"` and priority to 1.
 
 #### <a name="editdl">Edit a deadline : `edit`</a>
 
@@ -508,11 +522,11 @@ Edit a deadline to revise its name and due date/time.
 
 * `edit-deadline 1 dt-5pm`
 
-  Edit deadline with unique index of `1`'s due time to 5 pm.
+    Edit deadline with unique index of `1`'s due time to 5 pm.
 
 * `edit-deadline 2 dd-23/11/2016`
 
-  Edit deadline with unique index of `2`'s due date to 2016 23th November.
+    Edit deadline with unique index of `2`'s due date to 2016 23th November.
 
 #### <a name="edite">Edit an event : `edit`</a>
 
@@ -540,15 +554,16 @@ Edit an event to revise its name, starting/ending date/time and location.
 
 * `edit-event 6 loc-LT6`
 
-  Edit event with unique index of `6`'s location to `LT6`.
+    Edit event with unique index of `6`'s location to `LT6`.
 
 * `edit-event 2 st-4pm et-6pm`
 
-  Edit event with unique index of `00126`'s starting time to 4pm and ending time to 6pm.
+    Edit event with index of `2`'s starting time to 4pm and ending time to 6pm.
 
 * `edit-event 7 n-"proposal meeting" st-7pm`
 
-  Edit event with unique index of `7`'s starting time to 7pm and name to `proposal meeting`.
+    Edit event with unique index of `7`'s starting time to 7pm and name to
+    `proposal meeting`.
 
 ### <a name="fin">Mark a floating task/deadline as done/finished: `fin`</a>
 
@@ -567,7 +582,7 @@ will be archived.
 
 * `fin-float 1`
 
-  Marked floating task `1` as finished.
+    Marked floating task `1` as finished.
 
 ### <a name="slot"> Show empty time slots : `slot`</a>
 
@@ -585,18 +600,18 @@ Show all empty time slots in a given time period with a given duration.
 
 * `slot 1/11/2016 3/11/2016 h-4`
 
-  The TaskTracker will generate all empty time slots that are equal or greater than 4 hours
-  between 2016 1st November 0am to 3rd 11:59pm.
+    The TaskTracker will generate all empty time slots that are equal or
+    greater than 4 hours between 2016 1st November 12am to 3rd 11:59pm.
 
 * `slot 5/11/2016 2pm 11pm m-45`
 
-  The TaskTracker will generate all empty time slots that are equal or greater than 45 minutes
-  between 2016 5st November 2pm to 3rd 11:00pm.
+    The TaskTracker will generate all empty time slots that are equal or
+    greater than 45 minutes between 2016 5st November 2pm to 3rd 11:00pm.
 
 * `slot 5/11/2016 2pm m-45`
 
-  The TaskTracker will generate all empty time slots that are equal or greater than 45 minutes
-  between 2016 5st November 0am to 2pm.
+    The TaskTracker will generate all empty time slots that are equal or
+    greater than 45 minutes between 2016 5st November 12am to 2pm.
 
 ### <a name="view"> Toggle views: `view` </a>
 
@@ -636,13 +651,13 @@ Search task that contains specific keywords.
 
 * `search lecture`
 
-  Search for all the tasks that contain keyword `lecture`, TaskTracker will
-  generate a list for view.
+    Search for all the tasks that contain keyword `lecture`, TaskTracker will
+    generate a list for view.
 
 * `search training SESSION`
 
-  Search for all the tasks that contain keyword `training SESSION`, TaskTracker
-  will generate a list for view.
+    Search for all the tasks that contain keyword `training SESSION`,
+    TaskTracker will generate a list for view.
 
 ### <a name="undo"> Undo an action : `undo`</a>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,3 +1,14 @@
+---
+title: Task Tracker
+papersize: A4
+documentclass: report
+numbersections: true
+geometry: margin=2.4cm
+mainfont: Myriad Pro
+monofont: Inconsolata
+fontsize: 11pt
+---
+
 # User Guide
 
 * [About] (#about)

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -329,7 +329,7 @@ Valid input examples:
 
 If the minute field is `00`, it may be ommitted from the command.
 
-### <a name="help">Viewing help : `help`</a>
+### <a name="help">Viewing help: `help`</a>
 
 ```
 help
@@ -339,7 +339,7 @@ Help is also shown if you enter an incorrect command e.g. `abcd`
 
 ![alt text](./images/userguide/help.png "")
 
-### <a name="addft">Adding a floating task : `add`</a>
+### <a name="addft">Adding a floating task: `add`</a>
 
 Adds a floating task to TaskTracker.
 
@@ -372,7 +372,7 @@ not allowed in task name.
 
   To create a task called `Progress Reflection` with default `PRIORITY` of 0.
 
-### <a name="adddt"> Adding a deadline task: `add`</a>
+### <a name="adddt">Adding a deadline task: `add`</a>
 
 Adds a deadline with specific due date and time to TaskTracker.
 
@@ -408,7 +408,7 @@ add <"DEADLINE_NAME"> <DATE> <TIME> [PRIORITY]
 
     To create a deadline named `EE2024 homework 1` tommorow, 6 am.
 
-### <a name="adde"> Adding an event: `add`</a>
+### <a name="adde">Adding an event: `add`</a>
 
 Adds an event with specific start date, start time and end date, end time to
 TaskTracker.
@@ -446,7 +446,7 @@ add <"EVENT_NAME"> <START_DATE> <START_TIME> <END_DATE> <END_TIME> [loc-LOCATION
     To create an event `sports training camp` with starting date 1 December
     2016, starting time 7pm, ending date 10 January 2017 and ending time 1pm.
 
-### <a name="del"> Deleting a floating task/event/deadline: `del`</a>
+### <a name="del">Deleting a floating task/event/deadline: `del`</a>
 
 Delete a useless floating task/event/deadline on TaskTracker.
 
@@ -476,7 +476,7 @@ del-float|-deadline|-event <INDEX>
 
 * The `[optional parameters]` need not follow the order shown.
 
-#### <a name="editft"> Edit a floating task: `edit` </a>
+#### <a name="editft">Edit a floating task: `edit`</a>
 
 Edit a floating task to revise its name or priority.
 
@@ -597,7 +597,7 @@ fin-float|-deadline|-event <INDEX>
 
     Marked floating task `1` as finished.
 
-### <a name="slot"> Show empty time slots : `slot`</a>
+### <a name="slot">Show empty time slots: `slot`</a>
 
 Show all empty time slots in a given time period with a given duration.
 
@@ -628,7 +628,7 @@ slot <STARTING_DATE> <STARTING_TIME> <ENDING_DATE> <ENDING_TIME> <h-HOUR> <m-MIN
     The TaskTracker will generate all empty time slots that are equal or
     greater than 45 minutes between 2016 5st November 12am to 2pm.
 
-### <a name="view"> Toggle views: `view` </a>
+### <a name="view">Toggle views: `view`</a>
 
 #### View all events that start on and all deadline tasks due on a specific date.
 
@@ -654,7 +654,7 @@ view all
 
   View all the tasks that are of the date of 1st December of the current year.
 
-### <a name="search"> Search by keywords: `search`</a>
+### <a name="search">Search by keywords: `search`</a>
 
 Search task that contains specific keywords.
 
@@ -680,7 +680,7 @@ search <KEY_WORDS>
     Search for all the tasks that contain keyword `training SESSION`,
     TaskTracker will generate a list for view.
 
-### <a name="undo"> Undo an action : `undo`</a>
+### <a name="undo">Undo an action: `undo`</a>
 
 Undo the previous action that modifies data. Undo can be performed many times until the first action since the app was launched has been undone.
 
@@ -694,7 +694,7 @@ View the stack of actions that undo will perform: `undo stack`
 undo stack
 ```
 
-### <a name="redo"> Redo an action : `redo`</a>
+### <a name="redo">Redo an action: `redo`</a>
 
 Redo the previous action that was undone by undo. The amount of consecutive redos doable is equal to the number of consecutive undos performed right before redo is entered.
 
@@ -708,7 +708,7 @@ View the stack of actions that redo will perform: `redo stack`
 redo stack
 ```
 
-### <a name="clear"> Clearing all entries : `clear`</a>
+### <a name="clear">Clearing all entries: `clear`</a>
 
 Clears all entries from TaskTracker.
 
@@ -716,7 +716,7 @@ Clears all entries from TaskTracker.
 clear
 ```
 
-### <a name="exit"> Exiting the program : `exit`</a>
+### <a name="exit">Exiting the program: `exit`</a>
 
 Exits the program.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -7,9 +7,12 @@ geometry: margin=2.4cm
 mainfont: Myriad Pro
 monofont: Inconsolata
 fontsize: 11pt
+toc: true
 ---
 
 # User Guide
+
+<!-- BEGIN GITHUB -->
 
 * [About] (#about)
 * [Quick Start](#quick-start)
@@ -36,6 +39,8 @@ fontsize: 11pt
     * [Clear](#clear)
     * [Exit](#exit)
 * [Command Summary](#command-summary)
+
+<!-- END GITHUB -->
 
 ## About
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -231,7 +231,7 @@ the type and number of fields entered when creating the task.
 
 All the time and date fields of the task have to be entered in order to create the task.
 
-<a name="cf">**Command Format**</a>
+### <a name="cf">Command Format</a>
 
 * Words in `UPPER_CASE` are parameters to be defined by the user.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -68,7 +68,7 @@ TaskTracker makes time-management smart and simple for you!
 
 1. Ensure you have Java version `1.8.0_60` or later installed in your computer.
 
-    > Having any Java 8 version is not enough.
+    > Note: Having any Java 8 version is not enough.
     > This app will not work with earlier versions of Java 8.
 
 2. Download the latest `TaskTracker.jar` from the 'releases' tab.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -136,15 +136,21 @@ TaskTracker makes time-management smart and simple for you!
 
 10. To delete a task, try:
 
-        del-float 2
+    ```
+    del-float 2
+    ```
 
     Delete floating task `bake potatoes`.
 
-        del-deadline 1
+    ```
+    del-deadline 1
+    ```
 
     Delete deadline task `bake cookies`.
 
-        del-event 4
+    ```
+    del-event 4
+    ```
 
     Delete Event `Trick or treat`.
 
@@ -325,7 +331,9 @@ If the minute field is `00`, it may be ommitted from the command.
 
 ### <a name="help">Viewing help : `help`</a>
 
-    help
+```
+help
+```
 
 Help is also shown if you enter an incorrect command e.g. `abcd`
 
@@ -335,7 +343,9 @@ Help is also shown if you enter an incorrect command e.g. `abcd`
 
 Adds a floating task to TaskTracker.
 
-    add <"FLOATING_TASK_NAME"> [PRIORITY]
+```
+add <"FLOATING_TASK_NAME"> [PRIORITY]
+```
 
 * Task name should be in a pair of quotation marks. And quotations marks are
 not allowed in task name.
@@ -366,7 +376,9 @@ not allowed in task name.
 
 Adds a deadline with specific due date and time to TaskTracker.
 
-    add <"DEADLINE_NAME"> <DATE> <TIME> [PRIORITY]
+```
+add <"DEADLINE_NAME"> <DATE> <TIME> [PRIORITY]
+```
 
 * Deadline name should be in a pair of quotation marks. And quotations marks
   are not allowed in deadline name.
@@ -401,7 +413,9 @@ Adds a deadline with specific due date and time to TaskTracker.
 Adds an event with specific start date, start time and end date, end time to
 TaskTracker.
 
-    add <"EVENT_NAME"> <START_DATE> <START_TIME> <END_DATE> <END_TIME> [loc-LOCATION]
+```
+add <"EVENT_NAME"> <START_DATE> <START_TIME> <END_DATE> <END_TIME> [loc-LOCATION]
+```
 
 * Event name should be within a pair of quotation marks. Quotations marks are
   not allowed in event name.
@@ -436,7 +450,9 @@ TaskTracker.
 
 Delete a useless floating task/event/deadline on TaskTracker.
 
-    del-float|-deadline|-event <INDEX>
+```
+del-float|-deadline|-event <INDEX>
+```
 
 * Every event, deadline and floating task will have their own unique index.
 
@@ -469,8 +485,9 @@ Edit a floating task to revise its name or priority.
 | n- | name |
 | p- | priority |
 
-
-    edit-float <INDEX> [n-NEW_NAME | p-PRIORITY]...
+```
+edit-float <INDEX> [n-NEW_NAME | p-PRIORITY]...
+```
 
 * Quotation marks are not necessary for `NEW_NAME`.
 
@@ -501,7 +518,9 @@ Edit a deadline to revise its name and due date/time.
 | dd- | due date |
 | dt- | due time |
 
-    edit-deadline <INDEX> [dd-DUE_DATE | dt-DUE_TIME | n-NEW_NAME]...
+```
+edit-deadline <INDEX> [dd-DUE_DATE | dt-DUE_TIME | n-NEW_NAME]...
+```
 
 * Quotation marks are not necessary for `NEW_NAME`.
 
@@ -531,9 +550,11 @@ Edit an event to revise its name, starting/ending date/time and location.
 | et- | end time |
 | loc-| location |
 
-    edit-event <INDEX> [ n-NEW_NAME | sd-NEW_START_TIME | st-NEW_START_DATE
-                        | ed-NEW_END_DATE | et-NEW_END_TIME | n-NEW_NAME
-                        | loc-NEW_LOCATION]...
+```
+edit-event <INDEX> [ n-NEW_NAME | sd-NEW_START_TIME | st-NEW_START_DATE
+                    | ed-NEW_END_DATE | et-NEW_END_TIME | n-NEW_NAME
+                    | loc-NEW_LOCATION]...
+```
 
 * Quotation marks are not necessary for `NEW_NAME`.
 
@@ -560,7 +581,9 @@ Edit an event to revise its name, starting/ending date/time and location.
 Mark a floating task/event/deadline as done on TaskTracker, the marked tasks
 will be archived.
 
-    fin-float|-deadline|-event <INDEX>
+```
+fin-float|-deadline|-event <INDEX>
+```
 
 * Events that have already passed it `DUE_TIME` will be marked as done
   automatically.
@@ -578,7 +601,9 @@ will be archived.
 
 Show all empty time slots in a given time period with a given duration.
 
-    slot <STARTING_DATE> <STARTING_TIME> <ENDING_DATE> <ENDING_TIME> <h-HOUR> <m-MINUTE>
+```
+slot <STARTING_DATE> <STARTING_TIME> <ENDING_DATE> <ENDING_TIME> <h-HOUR> <m-MINUTE>
+```
 
 * At least one of `<STARTING_DATE> <STARTING_TIME>` is required.
 
@@ -607,7 +632,9 @@ Show all empty time slots in a given time period with a given duration.
 
 #### View all events that start on and all deadline tasks due on a specific date.
 
-    view <DATE>
+```
+view <DATE>
+```
 
 * `DATE` will follow the format shown in [Date Format](#DateFormat)
 
@@ -615,7 +642,9 @@ Show all empty time slots in a given time period with a given duration.
 
 #### View all time events and deadline task
 
-	view all
+```
+view all
+```
 
 * All the task in the database will be displayed.
 
@@ -629,7 +658,9 @@ Show all empty time slots in a given time period with a given duration.
 
 Search task that contains specific keywords.
 
-    search <KEY_WORDS>
+```
+search <KEY_WORDS>
+```
 
 * The `KEY_WORDS` are CASE-SENSITIVE
 
@@ -653,33 +684,45 @@ Search task that contains specific keywords.
 
 Undo the previous action that modifies data. Undo can be performed many times until the first action since the app was launched has been undone.
 
-    undo
+```
+undo
+```
 
 View the stack of actions that undo will perform: `undo stack`
 
-    undo stack
+```
+undo stack
+```
 
 ### <a name="redo"> Redo an action : `redo`</a>
 
 Redo the previous action that was undone by undo. The amount of consecutive redos doable is equal to the number of consecutive undos performed right before redo is entered.
 
-    redo
+```
+redo
+```
 
 View the stack of actions that redo will perform: `redo stack`
 
-    redo stack
+```
+redo stack
+```
 
 ### <a name="clear"> Clearing all entries : `clear`</a>
 
 Clears all entries from TaskTracker.
 
-    clear
+```
+clear
+```
 
 ### <a name="exit"> Exiting the program : `exit`</a>
 
 Exits the program.
 
-    exit
+```
+exit
+```
 
 ## Command Summary
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -527,7 +527,9 @@ Edit an event to revise its name, starting/ending date/time and location.
 | et- | end time |
 | loc-| location |
 
-    edit-event <INDEX> [n-NEW_NAME | sd-NEW_START_TIME | st-NEW_START_DATE | ed-NEW_END_DATE | et-NEW_END_TIME | n-NEW_NAME | loc-NEW_LOCATION]...
+    edit-event <INDEX> [ n-NEW_NAME | sd-NEW_START_TIME | st-NEW_START_DATE
+                        | ed-NEW_END_DATE | et-NEW_END_TIME | n-NEW_NAME
+                        | loc-NEW_LOCATION]...
 
 * Quotation marks are not necessary for `NEW_NAME`.
 

--- a/pandoc/anchorheadings.py
+++ b/pandoc/anchorheadings.py
@@ -1,0 +1,22 @@
+#! /usr/bin/env python3
+from panflute import *
+import bs4
+import sys
+
+
+def anchor_headings(elem, doc):
+    if type(elem) != Header:
+        return
+    identifier = elem.identifier
+    for child in elem.content:
+        if type(child) == RawInline and child.format == 'html':
+            b = bs4.BeautifulSoup(child.text, 'html.parser')
+            if not b.a or 'name' not in b.a.attrs:
+                continue
+            identifier = b.a['name']
+    return Header(*elem.content, level=elem.level, identifier=identifier,
+                  classes=elem.classes, attributes=elem.attributes)
+
+
+if __name__ == '__main__':
+    toJSONFilter(anchor_headings)

--- a/pandoc/appendixrename.py
+++ b/pandoc/appendixrename.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python3
+from panflute import *
+import bs4
+import sys
+import re
+
+
+def appendix_rename(elem, doc):
+    if type(elem) != Header:
+        return
+    content = stringify(elem)
+    match = re.match(r'[aA]ppendix [A-Z]:\s+', content)
+    if not match:
+        return
+    return Header(Str(content[match.end():]), level=elem.level,
+            identifier=elem.identifier, classes=elem.classes,
+            attributes=elem.attributes)
+
+
+if __name__ == '__main__':
+    toJSONFilter(appendix_rename)

--- a/pandoc/githubonly.py
+++ b/pandoc/githubonly.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from panflute import *
+import re
+
+"""
+Pandoc filter that causes everything between
+'<!-- BEGIN GITHUB -->' and '<!-- END GITHUB -->'
+to be ignored.  The comment lines must appear on
+lines by themselves, with blank lines surrounding
+them.
+"""
+
+
+incomment = False
+
+
+def githubonly(elem, doc):
+    global incomment
+
+    if type(elem) is RawBlock and elem.format == 'html':
+        if re.search(r'<!-- BEGIN GITHUB -->', elem.text):
+            incomment = True
+            return []
+        elif re.search(r'<!-- END GITHUB -->', elem.text):
+            incomment = False
+            return []
+
+    if incomment:
+        return []  # suppress anything in a comment
+
+
+if __name__ == '__main__':
+    toJSONFilter(githubonly)

--- a/pandoc/latexblockquote.py
+++ b/pandoc/latexblockquote.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+from panflute import *
+import re
+import sys
+
+"""
+Converts blockquotes of the following form:
+> Note:
+
+to actual boxes with different colours.
+"""
+
+
+def latex_blockquote(elem, doc):
+    if type(elem) != BlockQuote:
+        return
+    content = stringify(elem).strip()
+    if not content.startswith('Note:'):
+        return
+    children = ([RawBlock(r'\begin{notebox}', format='latex')] +
+                list(elem.content) +
+                [RawBlock(r'\end{notebox}', format='latex')])
+    return children
+
+
+if __name__ == '__main__':
+    toJSONFilter(latex_blockquote)

--- a/pandoc/latexfigure.py
+++ b/pandoc/latexfigure.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from panflute import *
+import re
+import bs4
+
+"""
+Converts images represented in HTML blocks of
+<figure>
+<img src="...">
+<figcaption>Figure caption</figcaption>
+</figure>
+into proper LaTeX figures.
+"""
+
+
+def latex_figure(elem, doc):
+    if type(elem) != RawBlock or elem.format != 'html':
+        return
+    root = bs4.BeautifulSoup(elem.text, 'html.parser')
+    if not root.figure:
+        return
+    ltx = [r'\begin{figure}[H]', '\centering']
+    if root.figure.img:
+        src = root.figure.img['src']
+        ltx.append(r'\includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{'
+                   + src + '}')
+    if root.figure.figcaption:
+        caption = root.figure.figcaption.get_text().strip()
+        match = re.match(r'^Figure [\d.]+:\s+', caption)
+        if match:
+            caption = caption[match.end():]
+        ltx.append(r'\caption{' + caption + '}')
+    ltx.append(r'\end{figure}')
+    return RawBlock('\n'.join(ltx), format='latex')
+
+
+if __name__ == '__main__':
+    toJSONFilter(latex_figure)

--- a/pandoc/latexonly.py
+++ b/pandoc/latexonly.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from panflute import *
+import re
+
+"""
+Pandoc filter that causes the content of '<!-- BEGIN LATEX'
+and 'END LATEX -->' to be converted into a raw LateX block.
+"""
+
+BEGIN_LATEX = '<!-- BEGIN LATEX'
+END_LATEX = 'END LATEX -->'
+
+
+def latexonly(elem, doc):
+    if type(elem) is not RawBlock or elem.format != 'html':
+        return
+    if elem.text.startswith(BEGIN_LATEX) and elem.text.endswith(END_LATEX):
+        content = elem.text[len(BEGIN_LATEX):-len(END_LATEX)]
+        return RawBlock(content, format='latex')
+
+
+if __name__ == '__main__':
+    toJSONFilter(latexonly)

--- a/pandoc/templates/default.latex
+++ b/pandoc/templates/default.latex
@@ -1,0 +1,261 @@
+\documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$paper,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
+$if(fontfamily)$
+\usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
+$else$
+\usepackage{lmodern}
+$endif$
+$if(linestretch)$
+\usepackage{setspace}
+\setstretch{$linestretch$}
+$endif$
+\usepackage{amssymb,amsmath}
+\usepackage{ifxetex,ifluatex}
+\usepackage{fixltx2e} % provides \textsubscript
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
+  \usepackage[utf8]{inputenc}
+$if(euro)$
+  \usepackage{eurosym}
+$endif$
+\else % if luatex or xelatex
+  \ifxetex
+    \usepackage{mathspec}
+  \else
+    \usepackage{fontspec}
+  \fi
+  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
+$for(fontfamilies)$
+  \newfontfamily{$fontfamilies.name$}[$fontfamilies.options$]{$fontfamilies.font$}
+$endfor$
+$if(euro)$
+  \newcommand{\euro}{€}
+$endif$
+$if(mainfont)$
+    \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
+$endif$
+$if(sansfont)$
+    \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
+$endif$
+$if(monofont)$
+    \setmonofont[Mapping=tex-ansi$if(monofontoptions)$,$for(monofontoptions)$$monofontoptions$$sep$,$endfor$$endif$]{$monofont$}
+$endif$
+$if(mathfont)$
+    \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+$endif$
+$if(CJKmainfont)$
+    \usepackage{xeCJK}
+    \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+$endif$
+\fi
+% use upquote if available, for straight quotes in verbatim environments
+\IfFileExists{upquote.sty}{\usepackage{upquote}}{}
+% use microtype if available
+\IfFileExists{microtype.sty}{%
+\usepackage{microtype}
+\UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+}{}
+$if(geometry)$
+\usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
+$endif$
+\usepackage[unicode=true]{hyperref}
+$if(colorlinks)$
+\PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref
+$endif$
+\hypersetup{
+$if(title-meta)$
+            pdftitle={$title-meta$},
+$endif$
+$if(author-meta)$
+            pdfauthor={$author-meta$},
+$endif$
+$if(keywords)$
+            pdfkeywords={$for(keywords)$$keywords$$sep$; $endfor$},
+$endif$
+$if(colorlinks)$
+            colorlinks=true,
+            linkcolor=$if(linkcolor)$$linkcolor$$else$Maroon$endif$,
+            citecolor=$if(citecolor)$$citecolor$$else$Blue$endif$,
+            urlcolor=$if(urlcolor)$$urlcolor$$else$Blue$endif$,
+$else$
+            pdfborder={0 0 0},
+$endif$
+            breaklinks=true}
+\urlstyle{same}  % don't use monospace font for urls
+$if(lang)$
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \usepackage[shorthands=off,$for(babel-otherlangs)$$babel-otherlangs$,$endfor$main=$babel-lang$]{babel}
+$if(babel-newcommands)$
+  $babel-newcommands$
+$endif$
+\else
+  \usepackage{polyglossia}
+  \setmainlanguage[$polyglossia-lang.options$]{$polyglossia-lang.name$}
+$for(polyglossia-otherlangs)$
+  \setotherlanguage[$polyglossia-otherlangs.options$]{$polyglossia-otherlangs.name$}
+$endfor$
+\fi
+$endif$
+$if(natbib)$
+\usepackage{natbib}
+\bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
+$endif$
+$if(biblatex)$
+\usepackage[$if(biblio-style)$style=$biblio-style$,$endif$$for(biblatexoptions)$$biblatexoptions$$sep$,$endfor$]{biblatex}
+$for(bibliography)$
+\addbibresource{$bibliography$}
+$endfor$
+$endif$
+$if(listings)$
+\usepackage{listings}
+$endif$
+$if(lhs)$
+\lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}
+$endif$
+$if(highlighting-macros)$
+$highlighting-macros$
+$endif$
+$if(verbatim-in-note)$
+\usepackage{fancyvrb}
+\VerbatimFootnotes % allows verbatim text in footnotes
+$endif$
+$if(tables)$
+\usepackage{longtable,booktabs}
+$endif$
+$if(graphics)$
+\usepackage{graphicx,grffile}
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\makeatother
+% Scale images if necessary, so that they will not overflow the page
+% margins by default, and it is still possible to overwrite the defaults
+% using explicit options in \includegraphics[width, height, ...]{}
+\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+$endif$
+$if(links-as-notes)$
+% Make links footnotes instead of hotlinks:
+\renewcommand{\href}[2]{#2\footnote{\url{#1}}}
+$endif$
+$if(strikeout)$
+\usepackage[normalem]{ulem}
+% avoid problems with \sout in headers with hyperref:
+\pdfstringdefDisableCommands{\renewcommand{\sout}{}}
+$endif$
+$if(indent)$
+$else$
+\IfFileExists{parskip.sty}{%
+\usepackage{parskip}
+}{% else
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{6pt plus 2pt minus 1pt}
+}
+$endif$
+\setlength{\emergencystretch}{3em}  % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
+$if(numbersections)$
+\setcounter{secnumdepth}{$if(secnumdepth)$$secnumdepth$$else$5$endif$}
+$else$
+\setcounter{secnumdepth}{0}
+$endif$
+$if(subparagraph)$
+$else$
+% Redefines (sub)paragraphs to behave more like sections
+\ifx\paragraph\undefined\else
+\let\oldparagraph\paragraph
+\renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
+\fi
+\ifx\subparagraph\undefined\else
+\let\oldsubparagraph\subparagraph
+\renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
+\fi
+$endif$
+$if(dir)$
+\ifxetex
+  % load bidi as late as possible as it modifies e.g. graphicx
+  $if(latex-dir-rtl)$
+  \usepackage[RTLdocument]{bidi}
+  $else$
+  \usepackage{bidi}
+  $endif$
+\fi
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  \TeXXeTstate=1
+  \newcommand{\RL}[1]{\beginR #1\endR}
+  \newcommand{\LR}[1]{\beginL #1\endL}
+  \newenvironment{RTL}{\beginR}{\endR}
+  \newenvironment{LTR}{\beginL}{\endL}
+\fi
+$endif$
+$for(header-includes)$
+$header-includes$
+$endfor$
+
+$if(title)$
+\title{$title$$if(thanks)$\thanks{$thanks$}$endif$}
+$endif$
+$if(subtitle)$
+\providecommand{\subtitle}[1]{}
+\subtitle{$subtitle$}
+$endif$
+$if(author)$
+\author{$for(author)$$author$$sep$ \and $endfor$}
+$endif$
+$if(institute)$
+\institute{$for(institute)$$institute$$sep$ \and $endfor$}
+$endif$
+\date{$date$}
+
+\begin{document}
+$if(title)$
+\maketitle
+$endif$
+$if(abstract)$
+\begin{abstract}
+$abstract$
+\end{abstract}
+$endif$
+
+$for(include-before)$
+$include-before$
+
+$endfor$
+$if(toc)$
+{
+$if(colorlinks)$
+\hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$black$endif$}
+$endif$
+\setcounter{tocdepth}{$toc-depth$}
+\tableofcontents
+}
+$endif$
+$if(lot)$
+\listoftables
+$endif$
+$if(lof)$
+\listoffigures
+$endif$
+$body$
+
+$if(natbib)$
+$if(bibliography)$
+$if(biblio-title)$
+$if(book-class)$
+\renewcommand\bibname{$biblio-title$}
+$else$
+\renewcommand\refname{$biblio-title$}
+$endif$
+$endif$
+\bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
+
+$endif$
+$endif$
+$if(biblatex)$
+\printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
+
+$endif$
+$for(include-after)$
+$include-after$
+
+$endfor$
+\end{document}

--- a/pandoc/templates/default.latex
+++ b/pandoc/templates/default.latex
@@ -10,6 +10,7 @@ $if(linestretch)$
 $endif$
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
+\usepackage{enumitem}
 \usepackage{fixltx2e} % provides \textsubscript
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}

--- a/pandoc/templates/default.latex
+++ b/pandoc/templates/default.latex
@@ -8,6 +8,7 @@ $if(linestretch)$
 \usepackage{setspace}
 \setstretch{$linestretch$}
 $endif$
+\usepackage{float}
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
 \usepackage{enumitem}

--- a/pandoc/templates/default.latex
+++ b/pandoc/templates/default.latex
@@ -106,8 +106,25 @@ $for(bibliography)$
 \addbibresource{$bibliography$}
 $endfor$
 $endif$
+\usepackage{tcolorbox}
+\tcbuselibrary{skins}
 $if(listings)$
 \usepackage{listings}
+\lstset{
+    language=,
+    basicstyle=\ttfamily,
+    breaklines=true
+}
+\tcolorboxenvironment{lstlisting}{
+    standard,
+    left=2mm,
+    top=0mm,
+    right=2mm,
+    bottom=0mm,
+    boxsep=0mm,
+    arc=0.5mm,
+    boxrule=0.4mm
+}
 $endif$
 $if(lhs)$
 \lstnewenvironment{code}{\lstset{language=Haskell,basicstyle=\small\ttfamily}}{}

--- a/pandoc/templates/default.latex
+++ b/pandoc/templates/default.latex
@@ -109,6 +109,13 @@ $endfor$
 $endif$
 \usepackage{tcolorbox}
 \tcbuselibrary{skins}
+\newtcolorbox{notebox}{
+    colback=blue!10!white,
+    sharp corners,
+    boxrule=0.4mm,
+    colframe=blue!50!black,
+    leftrule=3mm
+}
 $if(listings)$
 \usepackage{listings}
 \lstset{


### PR DESCRIPTION
supersedes #44
fixes #43 
## Generating the PDF

Somehow setup [pandoc](http://pandoc.org/), [python3](https://www.python.org/), [panflute](https://pypi.python.org/pypi/panflute/1.1.0), [beautifulsoup](https://www.crummy.com/software/BeautifulSoup/), and XeLaTeX, and then run

```
gradle pandoc
```

;)
## New Markup Features

All @CS2103AUG2016-T11-C4/developers  take note of the new markup features:
### Note boxes

(Don't know the proper term for it)

Putting a `Note:` in front of a blockquote will make put it in a blue note box.

```
> Note: Having any Java 8 version is not enough.
> This app will not work with earlier versions of Java 8.
```

Github rendering:
![callout1](https://cloud.githubusercontent.com/assets/109479/19409361/1059b2cc-9305-11e6-983d-13fefc7dcbff.png)

PDF rendering:
![callout2](https://cloud.githubusercontent.com/assets/109479/19409364/19d8a7e0-9305-11e6-8dc1-b1d170db46d4.png)
### Figure captions

Have to use HTML for this one (see DeveloperGuide.md for examples):

```
<figure>
<img src="images/devguide/comp-model.png">
<figcaption><div align="center">Figure 2.2: Model component class diagram</div></figcaption>
</figure>
```

Github rendering:
![figure1](https://cloud.githubusercontent.com/assets/109479/19409377/60cff34c-9305-11e6-9250-83547320463f.png)

PDF rendering:
![figure2](https://cloud.githubusercontent.com/assets/109479/19409380/66537672-9305-11e6-8f0c-652fb1cd3573.png)
### Github-only sections

Parts of the document surrounded by `<!-- BEGIN GITHUB -->` and `<!-- END GITHUB -->` will only be displayed in Github.

```
# Developer Guide

<!-- BEGIN GITHUB -->

* [Setting Up](#setting-up)
* [Design](#design)
* [Implementation](#implementation)
* [Testing](#testing)
* [Appendix A: User Stories](#appendix-a-user-stories)
* [Appendix B: Use Cases](#appendix-b-use-cases)
* [Appendix C: Non Functional Requirements](#appendix-c-non-functional-requirements)
* [Appendix D: Glossary](#appendix-d-glossary)
* [Appendix E: Product Survey](#appendix-e-product-survey)

<!-- END GITHUB -->

## Setting up
```

Github rendering:
![github1](https://cloud.githubusercontent.com/assets/109479/19409388/a227ce32-9305-11e6-8e65-56dba8331b1e.png)

PDF rendering (notice how the list of contents is missing):
![github2](https://cloud.githubusercontent.com/assets/109479/19409394/a78af5b6-9305-11e6-9afc-8cb601c498b2.png)
### LaTeX-only sections

Parts surrounded by `<!-- BEGIN LATEX` and `END LATEX -->` will only be shown in the PDF output.

e.g. in DeveloperGuide.md:

```
<dl>
  <dt>Task book</dt>
  <dd>The database where events, deadlines and floating tasks are stored.</dd>

  <dt>Datetime</dt>
  <dd>Date and Time</dd>

  <dt>Task</dt>
  <dd>A unit of information in the task book database. Each task has a name.</dd>

  <dt>Event</dt>
  <dd>Task that has a start datetime and end datetime</dd>

  <dt>Deadline</dt>
  <dd>Task that has an end datetime only.</dd>

  <dt>Floating task</dt>
  <dd>A task that has neither a start datetime not end datetime.</dd>

  <dt>Time slot</dt>
  <dd>A time slot is referring to a period of time</dd>
</dl>

<!-- BEGIN LATEX

\begin{description}

\item[Task book] \hfill \\
    The database where events, deadlines and floating tasks are stored.

\item[Datetime] \hfill \\
    Date and time

\item[Task] \hfill \\
    A unit of information in the task book database. Each task has a name.

\item[Event] \hfill \\
    Task that has a start datetime and end datetime.

\item[Deadline] \hfill \\
    Task that has an end datetime only.

\item[Floating task] \hfill \\
    A task that has neither a start datetime nor end datetime.

\item[Time slot] \hfill \\
    A time slot is referring to a period of time.

\end{description}

END LATEX -->
```

Github rendering (it renders the HTML part):
![latex1](https://cloud.githubusercontent.com/assets/109479/19409424/feb516e6-9305-11e6-8a19-ada1bdcb1d64.png)

PDF rendering (it renders the LaTeX part):
![latex2](https://cloud.githubusercontent.com/assets/109479/19409428/032bd6e2-9306-11e6-9bcb-3385e8604641.png)
