### PR TITLE
Make task abstract

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -18,22 +18,9 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";
 
-    private final Task toAdd;
-
-    /**
-     * Convenience constructor using raw values.
-     *
-     * @throws IllegalValueException if any of the raw values are invalid
-     */
-    public AddCommand(String name) throws IllegalValueException {
-        this.toAdd = new Task(new Name(name));
-    }
-
-    @Override
-    public CommandResult execute() {
-        assert model != null;
-        model.addTask(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
-    }
-
+	@Override
+	public CommandResult execute() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,9 +1,5 @@
 package seedu.address.logic.commands;
 
-import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.task.Name;
-import seedu.address.model.task.Task;
-
 /**
  * Adds a person to the task book.
  */
@@ -18,9 +14,9 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";
 
-	@Override
-	public CommandResult execute() {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    @Override
+    public CommandResult execute() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/AddDeadlineCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddDeadlineCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.task.DeadlineTask;
  */
 public class AddDeadlineCommand extends Command {
 
-    public static final String COMMAND_WORD = "due";
+    public static final String COMMAND_WORD = "deadline";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a deadline to the task book. "
             + "Parameters: \"NAME\" <DUE_DATE> <DUE_TIME>\n"

--- a/src/main/java/seedu/address/logic/commands/AddFloatingTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddFloatingTaskCommand.java
@@ -10,7 +10,7 @@ import seedu.address.model.task.Priority;
  */
 public class AddFloatingTaskCommand extends Command {
 
-    public static final String COMMAND_WORD = "task";
+    public static final String COMMAND_WORD = "float";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an floating task to the task book. "
             + "Parameters: \"NAME\" [PRIORITY]\n"

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -79,9 +79,6 @@ public class Parser {
 		final String arguments = matcher.group("arguments");
 		switch (commandWord) {
 
-		case "add":
-			return prepareAdd(arguments);
-
 		case AddFloatingTaskCommand.COMMAND_WORD:
 			return new AddFloatingTaskParser().parse(arguments);
 
@@ -134,22 +131,6 @@ public class Parser {
 			return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
 		}
 	}
-
-	/**
-     * Parses arguments in the context of the add Task command.
-     *
-     * @param args full command args string
-     * @return the prepared command
-     */
-    private Command prepareAdd(String args) {
-    	args=args.trim();
-        final Matcher matcher = PERSON_DATA_ARGS_FORMAT.matcher(args.trim());//Todos: replace with TASK_DATA_ARGS_FORMAT
-        // Validate arg string format
-        if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        }
-        	return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));	
-    }
 
 	/**
 	 * Parses arguments in the context of the delete person command.

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -37,226 +37,283 @@ import seedu.address.logic.commands.SelectCommand;
  */
 public class Parser {
 
-    /**
-     * Used for initial separation of command word and args.
-     */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+	/**
+	 * Used for initial separation of command word and args.
+	 */
+	private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
-    private static final Pattern TASK_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
+	private static final Pattern TASK_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
 
-    private static final Pattern KEYWORDS_ARGS_FORMAT =
-            Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one or more keywords separated by whitespace
+	private static final Pattern KEYWORDS_ARGS_FORMAT = Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one
+																											// or
+																											// more
+																											// keywords
+																											// separated
+																											// by
+																											// whitespace
 
-    private static final Pattern PERSON_DATA_ARGS_FORMAT = // '/' forward slashes are reserved for delimiter prefixes
-            Pattern.compile("(?<name>[^/]+)");
+	private static final Pattern PERSON_DATA_ARGS_FORMAT = // '/' forward
+															// slashes are
+															// reserved for
+															// delimiter
+															// prefixes
+			Pattern.compile("(?<name>[^/]+)");
 
-    public Parser() {}
+	public Parser() {
+	}
 
-    /**
-     * Parses user input into command for execution.
-     *
-     * @param userInput full user input string
-     * @return the command based on the user input
-     */
-    public Command parseCommand(String userInput) {
-        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-        if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
-        }
+	/**
+	 * Parses user input into command for execution.
+	 *
+	 * @param userInput
+	 *            full user input string
+	 * @return the command based on the user input
+	 */
+	public Command parseCommand(String userInput) {
+		final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+		if (!matcher.matches()) {
+			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+		}
 
-        final String commandWord = matcher.group("commandWord");
-        final String arguments = matcher.group("arguments");
-        switch (commandWord) {
+		final String commandWord = matcher.group("commandWord");
+		final String arguments = matcher.group("arguments");
+		switch (commandWord) {
 
-        case AddCommand.COMMAND_WORD:
-            return prepareAdd(arguments);
+		case AddCommand.COMMAND_WORD:
+			return prepareAdd(arguments);
 
-        case AddFloatingTaskCommand.COMMAND_WORD:
-            return new AddFloatingTaskParser().parse(arguments);
+		case AddFloatingTaskCommand.COMMAND_WORD:
+			return new AddFloatingTaskParser().parse(arguments);
 
-        case AddEventCommand.COMMAND_WORD:
-            return new AddEventParser().parse(arguments);
+		case AddEventCommand.COMMAND_WORD:
+			return new AddEventParser().parse(arguments);
 
-        case AddDeadlineCommand.COMMAND_WORD:
-            return new AddDeadlineParser().parse(arguments);
+		case AddDeadlineCommand.COMMAND_WORD:
+			return new AddDeadlineParser().parse(arguments);
 
-        case SelectCommand.COMMAND_WORD:
-            return prepareSelect(arguments);
+		case SelectCommand.COMMAND_WORD:
+			return prepareSelect(arguments);
 
-        case DeleteCommand.COMMAND_WORD:
-            return prepareDelete(arguments);
+		case DeleteCommand.COMMAND_WORD:
+			return prepareDelete(arguments);
 
-        case DeleteFloatingTaskCommand.COMMAND_WORD:
-            return prepareDeleteFloatingTask(arguments);
+		case DeleteFloatingTaskCommand.COMMAND_WORD:
+			return prepareDeleteFloatingTask(arguments);
 
-        case EditFloatingTaskCommand.COMMAND_WORD:
-            return new EditFloatingTaskParser().parse(arguments);
+		case EditFloatingTaskCommand.COMMAND_WORD:
+			return new EditFloatingTaskParser().parse(arguments);
 
-        case DeleteEventCommand.COMMAND_WORD:
-            return prepareDeleteEvent(arguments);
+		case DeleteEventCommand.COMMAND_WORD:
+			return prepareDeleteEvent(arguments);
 
-        case EditEventCommand.COMMAND_WORD:
-            return new EditEventParser().parse(arguments);
+		case EditEventCommand.COMMAND_WORD:
+			return new EditEventParser().parse(arguments);
 
-        case DeleteDeadlineCommand.COMMAND_WORD:
-            return prepareDeleteDeadline(arguments);
+		case DeleteDeadlineCommand.COMMAND_WORD:
+			return prepareDeleteDeadline(arguments);
 
-        case EditDeadlineCommand.COMMAND_WORD:
-            return new EditDeadlineParser().parse(arguments);
+		case EditDeadlineCommand.COMMAND_WORD:
+			return new EditDeadlineParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+		case ClearCommand.COMMAND_WORD:
+			return new ClearCommand();
 
-        case FindCommand.COMMAND_WORD:
-            return prepareFind(arguments);
+		case FindCommand.COMMAND_WORD:
+			return prepareFind(arguments);
 
-        case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+		case ListCommand.COMMAND_WORD:
+			return new ListCommand();
 
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
+		case ExitCommand.COMMAND_WORD:
+			return new ExitCommand();
 
-        case HelpCommand.COMMAND_WORD:
-            return new HelpCommand();
+		case HelpCommand.COMMAND_WORD:
+			return new HelpCommand();
 
-        default:
-            return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
-        }
-    }
+		default:
+			return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+		}
+	}
 
-    /**
-     * Parses arguments in the context of the add person command.
+	/**
+     * Parses arguments in the context of the add Task command.
      *
      * @param args full command args string
      * @return the prepared command
      */
     private Command prepareAdd(String args) {
-        final Matcher matcher = PERSON_DATA_ARGS_FORMAT.matcher(args.trim());
+    	args=args.trim();
+        final Matcher matcher = PERSON_DATA_ARGS_FORMAT.matcher(args.trim());//Todos: replace with TASK_DATA_ARGS_FORMAT
         // Validate arg string format
         if (!matcher.matches()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
-        try {
-            return new AddCommand(matcher.group("name"));
-        } catch (IllegalValueException ive) {
-            return new IncorrectCommand(ive.getMessage());
+            String type = idTaskType(args);
+        	switch(type){
+        	case("float"):
+        		return new AddFloatingTaskParser().parse(args);
+        	
+        	case("deadline"):
+        		return new AddDeadlineParser().parse(args);
+        	
+        	case("event"):
+        		return new AddEventParser().parse(args);	
+        	}
+        	return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));	
         }
-    }
 
     /**
-     * Parses arguments in the context of the delete person command.
-     *
-     * @param args full command args string
-     * @return the prepared command
+     * Identifies the type of task.
+     * 
+     * @param args
+     * @return type of task as String
      */
-    private Command prepareDelete(String args) {
+	private String idTaskType(String args) {
+		int s = wordCount(args);
+		switch (s) {
+		case (1):
+			return "float";
 
-        Optional<Integer> index = parseIndex(args);
-        if (!index.isPresent()) {
-            return new IncorrectCommand(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        }
+		case (2):
+			return "float";
 
-        return new DeleteCommand(index.get());
-    }
+		case (3):
+			return "deadline";
 
-    /**
-     * Parses arguments in the context of the delete floating task command.
-     *
-     * @param args full command args string
-     * @return the prepared command
-     */
-    private Command prepareDeleteFloatingTask(String args) {
-        Optional<Integer> index = parseIndex(args);
-        if (!index.isPresent()) {
-            return new IncorrectCommand(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                  DeleteFloatingTaskCommand.MESSAGE_USAGE));
-        }
-        return new DeleteFloatingTaskCommand(index.get());
-    }
+		case (5):
+			return "event";
 
-    /**
-     * Parses arguments in the context of the delete event command.
-     *
-     * @param args full command args string
-     * @return the prepared command
-     */
-    private Command prepareDeleteEvent(String args) {
-        Optional<Integer> index = parseIndex(args);
-        if (!index.isPresent()) {
-            return new IncorrectCommand(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteEventCommand.MESSAGE_USAGE));
-        }
-        return new DeleteEventCommand(index.get());
-    }
+		case (6):
+			return "event";
+		}
+		return null;
+	}
 
-    /**
-     * Parses arguments in the context of the delete deadline command.
-     *
-     * @param args full command args string
-     * @return the prepared command
-     */
-    private Command prepareDeleteDeadline(String args) {
-        Optional<Integer> index = parseIndex(args);
-        if (!index.isPresent()) {
-            return new IncorrectCommand(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteDeadlineCommand.MESSAGE_USAGE));
-        }
-        return new DeleteDeadlineCommand(index.get());
-    }
+	public int wordCount(String s) {
+		if (s == null) {
+			return 0;
+		} else {
+			return s.trim().split("\\s+").length;
+		}
+	}
 
-    /**
-     * Parses arguments in the context of the select person command.
-     *
-     * @param args full command args string
-     * @return the prepared command
-     */
-    private Command prepareSelect(String args) {
-        Optional<Integer> index = parseIndex(args);
-        if (!index.isPresent()) {
-            return new IncorrectCommand(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
-        }
+	/**
+	 * Parses arguments in the context of the delete person command.
+	 *
+	 * @param args
+	 *            full command args string
+	 * @return the prepared command
+	 */
+	private Command prepareDelete(String args) {
 
-        return new SelectCommand(index.get());
-    }
+		Optional<Integer> index = parseIndex(args);
+		if (!index.isPresent()) {
+			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+		}
 
-    /**
-     * Returns the specified index in the {@code command} IF a positive unsigned integer is given as the index.
-     *   Returns an {@code Optional.empty()} otherwise.
-     */
-    private Optional<Integer> parseIndex(String command) {
-        final Matcher matcher = TASK_INDEX_ARGS_FORMAT.matcher(command.trim());
-        if (!matcher.matches()) {
-            return Optional.empty();
-        }
+		return new DeleteCommand(index.get());
+	}
 
-        String index = matcher.group("targetIndex");
-        if (!StringUtil.isUnsignedInteger(index)) {
-            return Optional.empty();
-        }
-        return Optional.of(Integer.parseInt(index));
+	/**
+	 * Parses arguments in the context of the delete floating task command.
+	 *
+	 * @param args
+	 *            full command args string
+	 * @return the prepared command
+	 */
+	private Command prepareDeleteFloatingTask(String args) {
+		Optional<Integer> index = parseIndex(args);
+		if (!index.isPresent()) {
+			return new IncorrectCommand(
+					String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteFloatingTaskCommand.MESSAGE_USAGE));
+		}
+		return new DeleteFloatingTaskCommand(index.get());
+	}
 
-    }
+	/**
+	 * Parses arguments in the context of the delete event command.
+	 *
+	 * @param args
+	 *            full command args string
+	 * @return the prepared command
+	 */
+	private Command prepareDeleteEvent(String args) {
+		Optional<Integer> index = parseIndex(args);
+		if (!index.isPresent()) {
+			return new IncorrectCommand(
+					String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteEventCommand.MESSAGE_USAGE));
+		}
+		return new DeleteEventCommand(index.get());
+	}
 
-    /**
-     * Parses arguments in the context of the find person command.
-     *
-     * @param args full command args string
-     * @return the prepared command
-     */
-    private Command prepareFind(String args) {
-        final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
-        if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    FindCommand.MESSAGE_USAGE));
-        }
+	/**
+	 * Parses arguments in the context of the delete deadline command.
+	 *
+	 * @param args
+	 *            full command args string
+	 * @return the prepared command
+	 */
+	private Command prepareDeleteDeadline(String args) {
+		Optional<Integer> index = parseIndex(args);
+		if (!index.isPresent()) {
+			return new IncorrectCommand(
+					String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteDeadlineCommand.MESSAGE_USAGE));
+		}
+		return new DeleteDeadlineCommand(index.get());
+	}
 
-        // keywords delimited by whitespace
-        final String[] keywords = matcher.group("keywords").split("\\s+");
-        final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
-        return new FindCommand(keywordSet);
-    }
+	/**
+	 * Parses arguments in the context of the select person command.
+	 *
+	 * @param args
+	 *            full command args string
+	 * @return the prepared command
+	 */
+	private Command prepareSelect(String args) {
+		Optional<Integer> index = parseIndex(args);
+		if (!index.isPresent()) {
+			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
+		}
+
+		return new SelectCommand(index.get());
+	}
+
+	/**
+	 * Returns the specified index in the {@code command} IF a positive unsigned
+	 * integer is given as the index. Returns an {@code Optional.empty()}
+	 * otherwise.
+	 */
+	private Optional<Integer> parseIndex(String command) {
+		final Matcher matcher = TASK_INDEX_ARGS_FORMAT.matcher(command.trim());
+		if (!matcher.matches()) {
+			return Optional.empty();
+		}
+
+		String index = matcher.group("targetIndex");
+		if (!StringUtil.isUnsignedInteger(index)) {
+			return Optional.empty();
+		}
+		return Optional.of(Integer.parseInt(index));
+
+	}
+
+	/**
+	 * Parses arguments in the context of the find person command.
+	 *
+	 * @param args
+	 *            full command args string
+	 * @return the prepared command
+	 */
+	private Command prepareFind(String args) {
+		final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
+		if (!matcher.matches()) {
+			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+		}
+
+		// keywords delimited by whitespace
+		final String[] keywords = matcher.group("keywords").split("\\s+");
+		final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
+		return new FindCommand(keywordSet);
+	}
 
 }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -10,9 +10,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.StringUtil;
-import seedu.address.logic.commands.AddCommand;
+
 import seedu.address.logic.commands.AddDeadlineCommand;
 import seedu.address.logic.commands.AddEventCommand;
 import seedu.address.logic.commands.AddFloatingTaskCommand;
@@ -37,218 +36,206 @@ import seedu.address.logic.commands.SelectCommand;
  */
 public class Parser {
 
-	/**
-	 * Used for initial separation of command word and args.
-	 */
-	private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
-	private static final Pattern TASK_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
+    private static final Pattern TASK_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
 
-	private static final Pattern KEYWORDS_ARGS_FORMAT = Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one
-																											// or
-																											// more
-																											// keywords
-																											// separated
-																											// by
-																											// whitespace
+    private static final Pattern KEYWORDS_ARGS_FORMAT = Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one or more keywords seperated by whitespace
 
-	private static final Pattern PERSON_DATA_ARGS_FORMAT = // '/' forward
-															// slashes are
-															// reserved for
-															// delimiter
-															// prefixes
-			Pattern.compile("(?<name>[^/]+)");
+    private static final Pattern PERSON_DATA_ARGS_FORMAT = Pattern.compile("(?<name>[^/]+)");
 
-	public Parser() {
-	}
+    public Parser() {
+    }
 
-	/**
-	 * Parses user input into command for execution.
-	 *
-	 * @param userInput
-	 *            full user input string
-	 * @return the command based on the user input
-	 */
-	public Command parseCommand(String userInput) {
-		final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
-		if (!matcher.matches()) {
-			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
-		}
+    /**
+  *Parses user input into command for execution.
+  *
+  * @param userInput
+  *            full user input string
+  * @return the command based on the user input
+  */
+    public Command parseCommand(String userInput) {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
 
-		final String commandWord = matcher.group("commandWord");
-		final String arguments = matcher.group("arguments");
-		switch (commandWord) {
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+        switch (commandWord) {
 
-		case AddFloatingTaskCommand.COMMAND_WORD:
-			return new AddFloatingTaskParser().parse(arguments);
+        case AddFloatingTaskCommand.COMMAND_WORD:
+            return new AddFloatingTaskParser().parse(arguments);
 
-		case AddEventCommand.COMMAND_WORD:
-			return new AddEventParser().parse(arguments);
+        case AddEventCommand.COMMAND_WORD:
+            return new AddEventParser().parse(arguments);
 
-		case AddDeadlineCommand.COMMAND_WORD:
-			return new AddDeadlineParser().parse(arguments);
+        case AddDeadlineCommand.COMMAND_WORD:
+            return new AddDeadlineParser().parse(arguments);
 
-		case SelectCommand.COMMAND_WORD:
-			return prepareSelect(arguments);
+        case SelectCommand.COMMAND_WORD:
+            return prepareSelect(arguments);
 
-		case DeleteCommand.COMMAND_WORD:
-			return prepareDelete(arguments);
+        case DeleteCommand.COMMAND_WORD:
+            return prepareDelete(arguments);
 
-		case DeleteFloatingTaskCommand.COMMAND_WORD:
-			return prepareDeleteFloatingTask(arguments);
+        case DeleteFloatingTaskCommand.COMMAND_WORD:
+            return prepareDeleteFloatingTask(arguments);
 
-		case EditFloatingTaskCommand.COMMAND_WORD:
-			return new EditFloatingTaskParser().parse(arguments);
+        case EditFloatingTaskCommand.COMMAND_WORD:
+            return new EditFloatingTaskParser().parse(arguments);
 
-		case DeleteEventCommand.COMMAND_WORD:
-			return prepareDeleteEvent(arguments);
+        case DeleteEventCommand.COMMAND_WORD:
+            return prepareDeleteEvent(arguments);
 
-		case EditEventCommand.COMMAND_WORD:
-			return new EditEventParser().parse(arguments);
+        case EditEventCommand.COMMAND_WORD:
+            return new EditEventParser().parse(arguments);
 
-		case DeleteDeadlineCommand.COMMAND_WORD:
-			return prepareDeleteDeadline(arguments);
+        case DeleteDeadlineCommand.COMMAND_WORD:
+            return prepareDeleteDeadline(arguments);
 
-		case EditDeadlineCommand.COMMAND_WORD:
-			return new EditDeadlineParser().parse(arguments);
+        case EditDeadlineCommand.COMMAND_WORD:
+            return new EditDeadlineParser().parse(arguments);
 
-		case ClearCommand.COMMAND_WORD:
-			return new ClearCommand();
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
 
-		case FindCommand.COMMAND_WORD:
-			return prepareFind(arguments);
+        case FindCommand.COMMAND_WORD:
+            return prepareFind(arguments);
 
-		case ListCommand.COMMAND_WORD:
-			return new ListCommand();
+        case ListCommand.COMMAND_WORD:
+            return new ListCommand();
 
-		case ExitCommand.COMMAND_WORD:
-			return new ExitCommand();
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand();
 
-		case HelpCommand.COMMAND_WORD:
-			return new HelpCommand();
+        default:
+            return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
 
-		default:
-			return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
-		}
-	}
-
-	/**
+    /**
 	 * Parses arguments in the context of the delete person command.
 	 *
 	 * @param args
 	 *            full command args string
 	 * @return the prepared command
 	 */
-	private Command prepareDelete(String args) {
+    private Command prepareDelete(String args) {
 
-		Optional<Integer> index = parseIndex(args);
-		if (!index.isPresent()) {
-			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-		}
+        Optional<Integer> index = parseIndex(args);
+        if (!index.isPresent()) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
 
-		return new DeleteCommand(index.get());
-	}
+        return new DeleteCommand(index.get());
+    }
 
-	/**
+    /**
 	 * Parses arguments in the context of the delete floating task command.
 	 *
 	 * @param args
 	 *            full command args string
 	 * @return the prepared command
 	 */
-	private Command prepareDeleteFloatingTask(String args) {
-		Optional<Integer> index = parseIndex(args);
-		if (!index.isPresent()) {
-			return new IncorrectCommand(
+    private Command prepareDeleteFloatingTask(String args) {
+        Optional<Integer> index = parseIndex(args);
+        if (!index.isPresent()) {
+            return new IncorrectCommand(
 					String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteFloatingTaskCommand.MESSAGE_USAGE));
-		}
-		return new DeleteFloatingTaskCommand(index.get());
-	}
+        }
+        return new DeleteFloatingTaskCommand(index.get());
+    }
 
-	/**
+    /**
 	 * Parses arguments in the context of the delete event command.
 	 *
 	 * @param args
 	 *            full command args string
 	 * @return the prepared command
 	 */
-	private Command prepareDeleteEvent(String args) {
-		Optional<Integer> index = parseIndex(args);
-		if (!index.isPresent()) {
-			return new IncorrectCommand(
+    private Command prepareDeleteEvent(String args) {
+        Optional<Integer> index = parseIndex(args);
+        if (!index.isPresent()) {
+            return new IncorrectCommand(
 					String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteEventCommand.MESSAGE_USAGE));
-		}
-		return new DeleteEventCommand(index.get());
-	}
+        }
+        return new DeleteEventCommand(index.get());
+    }
 
-	/**
+    /**
 	 * Parses arguments in the context of the delete deadline command.
 	 *
 	 * @param args
 	 *            full command args string
 	 * @return the prepared command
 	 */
-	private Command prepareDeleteDeadline(String args) {
-		Optional<Integer> index = parseIndex(args);
-		if (!index.isPresent()) {
-			return new IncorrectCommand(
+    private Command prepareDeleteDeadline(String args) {
+        Optional<Integer> index = parseIndex(args);
+        if (!index.isPresent()) {
+            return new IncorrectCommand(
 					String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteDeadlineCommand.MESSAGE_USAGE));
-		}
-		return new DeleteDeadlineCommand(index.get());
-	}
+        }
+        return new DeleteDeadlineCommand(index.get());
+    }
 
-	/**
+    /**
 	 * Parses arguments in the context of the select person command.
 	 *
 	 * @param args
 	 *            full command args string
 	 * @return the prepared command
 	 */
-	private Command prepareSelect(String args) {
-		Optional<Integer> index = parseIndex(args);
-		if (!index.isPresent()) {
-			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
-		}
+    private Command prepareSelect(String args) {
+        Optional<Integer> index = parseIndex(args);
+        if (!index.isPresent()) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
+        }
 
-		return new SelectCommand(index.get());
-	}
+        return new SelectCommand(index.get());
+    }
 
-	/**
+    /**
 	 * Returns the specified index in the {@code command} IF a positive unsigned
 	 * integer is given as the index. Returns an {@code Optional.empty()}
 	 * otherwise.
 	 */
-	private Optional<Integer> parseIndex(String command) {
-		final Matcher matcher = TASK_INDEX_ARGS_FORMAT.matcher(command.trim());
-		if (!matcher.matches()) {
-			return Optional.empty();
-		}
+    private Optional<Integer> parseIndex(String command) {
+        final Matcher matcher = TASK_INDEX_ARGS_FORMAT.matcher(command.trim());
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
 
-		String index = matcher.group("targetIndex");
-		if (!StringUtil.isUnsignedInteger(index)) {
-			return Optional.empty();
-		}
-		return Optional.of(Integer.parseInt(index));
+        String index = matcher.group("targetIndex");
+        if (!StringUtil.isUnsignedInteger(index)) {
+            return Optional.empty();
+        }
+        return Optional.of(Integer.parseInt(index));
 
-	}
+    }
 
-	/**
+    /**
 	 * Parses arguments in the context of the find person command.
 	 *
 	 * @param args
 	 *            full command args string
 	 * @return the prepared command
 	 */
-	private Command prepareFind(String args) {
-		final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
-		if (!matcher.matches()) {
-			return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-		}
+    private Command prepareFind(String args) {
+        final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
+        if (!matcher.matches()) {
+            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
 
-		// keywords delimited by whitespace
-		final String[] keywords = matcher.group("keywords").split("\\s+");
-		final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
-		return new FindCommand(keywordSet);
-	}
+        // keywords delimited by whitespace
+        final String[] keywords = matcher.group("keywords").split("\\s+");
+        final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
+        return new FindCommand(keywordSet);
+    }
 
 }

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -79,7 +79,7 @@ public class Parser {
 		final String arguments = matcher.group("arguments");
 		switch (commandWord) {
 
-		case AddCommand.COMMAND_WORD:
+		case "add":
 			return prepareAdd(arguments);
 
 		case AddFloatingTaskCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -45,8 +45,6 @@ public class Parser {
 
     private static final Pattern KEYWORDS_ARGS_FORMAT = Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)"); // one or more keywords seperated by whitespace
 
-    private static final Pattern PERSON_DATA_ARGS_FORMAT = Pattern.compile("(?<name>[^/]+)");
-
     public Parser() {
     }
 
@@ -120,12 +118,12 @@ public class Parser {
     }
 
     /**
-	 * Parses arguments in the context of the delete person command.
-	 *
-	 * @param args
-	 *            full command args string
-	 * @return the prepared command
-	 */
+     * Parses arguments in the context of the delete person command.
+    *
+    * @param args
+    *            full command args string
+    * @return the prepared command
+    */
     private Command prepareDelete(String args) {
 
         Optional<Integer> index = parseIndex(args);
@@ -137,60 +135,60 @@ public class Parser {
     }
 
     /**
-	 * Parses arguments in the context of the delete floating task command.
-	 *
-	 * @param args
-	 *            full command args string
-	 * @return the prepared command
-	 */
+     * Parses arguments in the context of the delete floating task command.
+     *
+     * @param args
+     *            full command args string
+     * @return the prepared command
+     */
     private Command prepareDeleteFloatingTask(String args) {
         Optional<Integer> index = parseIndex(args);
         if (!index.isPresent()) {
             return new IncorrectCommand(
-					String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteFloatingTaskCommand.MESSAGE_USAGE));
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteFloatingTaskCommand.MESSAGE_USAGE));
         }
         return new DeleteFloatingTaskCommand(index.get());
     }
 
     /**
-	 * Parses arguments in the context of the delete event command.
-	 *
-	 * @param args
-	 *            full command args string
-	 * @return the prepared command
-	 */
+     * Parses arguments in the context of the delete event command.
+     *
+     * @param args
+     *            full command args string
+     * @return the prepared command
+     */
     private Command prepareDeleteEvent(String args) {
         Optional<Integer> index = parseIndex(args);
         if (!index.isPresent()) {
             return new IncorrectCommand(
-					String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteEventCommand.MESSAGE_USAGE));
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteEventCommand.MESSAGE_USAGE));
         }
         return new DeleteEventCommand(index.get());
     }
 
     /**
-	 * Parses arguments in the context of the delete deadline command.
-	 *
-	 * @param args
-	 *            full command args string
-	 * @return the prepared command
-	 */
+     *  Parses arguments in the context of the delete deadline command.
+     *
+     * @param args
+     *            full command args string
+     * @return the prepared command
+     */
     private Command prepareDeleteDeadline(String args) {
         Optional<Integer> index = parseIndex(args);
         if (!index.isPresent()) {
             return new IncorrectCommand(
-					String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteDeadlineCommand.MESSAGE_USAGE));
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteDeadlineCommand.MESSAGE_USAGE));
         }
         return new DeleteDeadlineCommand(index.get());
     }
 
     /**
-	 * Parses arguments in the context of the select person command.
-	 *
-	 * @param args
-	 *            full command args string
-	 * @return the prepared command
-	 */
+     * Parses arguments in the context of the select person command.
+     *
+     * @param args
+     *            full command args string
+     * @return the prepared command
+     */
     private Command prepareSelect(String args) {
         Optional<Integer> index = parseIndex(args);
         if (!index.isPresent()) {
@@ -201,10 +199,10 @@ public class Parser {
     }
 
     /**
-	 * Returns the specified index in the {@code command} IF a positive unsigned
-	 * integer is given as the index. Returns an {@code Optional.empty()}
-	 * otherwise.
-	 */
+     * Returns the specified index in the {@code command} IF a positive unsigned
+     * integer is given as the index. Returns an {@code Optional.empty()}
+     * otherwise.
+     */
     private Optional<Integer> parseIndex(String command) {
         final Matcher matcher = TASK_INDEX_ARGS_FORMAT.matcher(command.trim());
         if (!matcher.matches()) {
@@ -220,12 +218,12 @@ public class Parser {
     }
 
     /**
-	 * Parses arguments in the context of the find person command.
-	 *
-	 * @param args
-	 *            full command args string
-	 * @return the prepared command
-	 */
+     * Parses arguments in the context of the find person command.
+     *
+     * @param args
+     *            full command args string
+     * @return the prepared command
+     */
     private Command prepareFind(String args) {
         final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(args.trim());
         if (!matcher.matches()) {

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -148,54 +148,8 @@ public class Parser {
         if (!matcher.matches()) {
             return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
-            String type = idTaskType(args);
-        	switch(type){
-        	case("float"):
-        		return new AddFloatingTaskParser().parse(args);
-        	
-        	case("deadline"):
-        		return new AddDeadlineParser().parse(args);
-        	
-        	case("event"):
-        		return new AddEventParser().parse(args);	
-        	}
         	return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));	
-        }
-
-    /**
-     * Identifies the type of task.
-     * 
-     * @param args
-     * @return type of task as String
-     */
-	private String idTaskType(String args) {
-		int s = wordCount(args);
-		switch (s) {
-		case (1):
-			return "float";
-
-		case (2):
-			return "float";
-
-		case (3):
-			return "deadline";
-
-		case (5):
-			return "event";
-
-		case (6):
-			return "event";
-		}
-		return null;
-	}
-
-	public int wordCount(String s) {
-		if (s == null) {
-			return 0;
-		} else {
-			return s.trim().split("\\s+").length;
-		}
-	}
+    }
 
 	/**
 	 * Parses arguments in the context of the delete person command.

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -8,7 +8,7 @@ import seedu.address.commons.util.CollectionUtil;
  * Represents a Task in the address book.
  * Guarantees: Is a POJO. Details are present and not null. Field values are validated and immutable.
  */
-public class Task {
+public abstract class Task {
 
     public final Name name;
 

--- a/src/test/java/guitests/TaskTrackerGuiTest.java
+++ b/src/test/java/guitests/TaskTrackerGuiTest.java
@@ -18,6 +18,7 @@ import guitests.guihandles.ResultDisplayHandle;
 import javafx.stage.Stage;
 import seedu.address.TestApp;
 import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.TaskBook;
 import seedu.address.testutil.TestUtil;
 import seedu.address.testutil.TypicalTestTasks;
@@ -77,7 +78,12 @@ public abstract class TaskTrackerGuiTest {
      */
     protected TaskBook getInitialData() {
         TaskBook ab = TestUtil.generateEmptyAddressBook();
-        TypicalTestTasks.loadAddressBookWithSampleData(ab);
+        try {
+			TypicalTestTasks.loadAddressBookWithSampleData(ab);
+		} catch (IllegalValueException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
         return ab;
     }
 

--- a/src/test/java/guitests/TaskTrackerGuiTest.java
+++ b/src/test/java/guitests/TaskTrackerGuiTest.java
@@ -79,11 +79,11 @@ public abstract class TaskTrackerGuiTest {
     protected TaskBook getInitialData() {
         TaskBook ab = TestUtil.generateEmptyAddressBook();
         try {
-			TypicalTestTasks.loadAddressBookWithSampleData(ab);
-		} catch (IllegalValueException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+            TypicalTestTasks.loadAddressBookWithSampleData(ab);
+        } catch (IllegalValueException e) {
+
+            e.printStackTrace();
+        }
         return ab;
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -37,6 +37,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyTaskBook;
 import seedu.address.model.TaskBook;
+import seedu.address.model.task.FloatingTask;
 import seedu.address.model.task.Name;
 import seedu.address.model.task.Task;
 import seedu.address.storage.StorageManager;
@@ -349,9 +350,9 @@ public class LogicManagerTest {
      */
     class TestDataHelper {
 
-        Task adam() throws Exception {
-            Name name = new Name("Adam Brown");
-            return new Task(name);
+        FloatingTask adam() throws Exception {
+            String name = "Adam Brown";
+            return new FloatingTask(name);
         }
 
         /**
@@ -362,9 +363,7 @@ public class LogicManagerTest {
          * @param seed used to generate the task data field values
          */
         Task generateTask(int seed) throws Exception {
-            return new Task(
-                    new Name("Task " + seed)
-            );
+            return new FloatingTask(new Name("Task " + seed).toString());
         }
 
         /** Generates the correct add command based on the task given */
@@ -449,9 +448,7 @@ public class LogicManagerTest {
          * Generates a Task object with given name. Other fields will have some dummy values.
          */
         Task generateTaskWithName(String name) throws Exception {
-            return new Task(
-                    new Name(name)
-            );
+            return new FloatingTask(name);
         }
     }
 }

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -29,6 +29,7 @@ import seedu.address.TestApp;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.FileUtil;
 import seedu.address.model.TaskBook;
+import seedu.address.model.task.FloatingTask;
 import seedu.address.model.task.Name;
 import seedu.address.model.task.Task;
 import seedu.address.storage.JsonStorageModule;
@@ -66,15 +67,15 @@ public class TestUtil {
     private static Task[] getSampleTaskData() {
         try {
             return new Task[]{
-                new Task(new Name("Ali Muster")),
-                new Task(new Name("Boris Mueller")),
-                new Task(new Name("Carl Kurz")),
-                new Task(new Name("Daniel Meier")),
-                new Task(new Name("Elle Meyer")),
-                new Task(new Name("Fiona Kunz")),
-                new Task(new Name("George Best")),
-                new Task(new Name("Hoon Meier")),
-                new Task(new Name("Ida Mueller"))
+                new FloatingTask("Ali Muster"),
+                new FloatingTask("Boris Mueller"),
+                new FloatingTask("Carl Kurz"),
+                new FloatingTask("Daniel Meier"),
+                new FloatingTask("Elle Meyer"),
+                new FloatingTask("Fiona Kunz"),
+                new FloatingTask("George Best"),
+                new FloatingTask("Hoon Meier"),
+                new FloatingTask("Ida Mueller")
             };
         } catch (IllegalValueException e) {
             assert false;

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -30,7 +30,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.FileUtil;
 import seedu.address.model.TaskBook;
 import seedu.address.model.task.FloatingTask;
-import seedu.address.model.task.Name;
+
 import seedu.address.model.task.Task;
 import seedu.address.storage.JsonStorageModule;
 

--- a/src/test/java/seedu/address/testutil/TypicalTestTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTestTasks.java
@@ -2,6 +2,7 @@ package seedu.address.testutil;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.TaskBook;
+import seedu.address.model.task.FloatingTask;
 import seedu.address.model.task.Task;
 
 /**
@@ -46,14 +47,14 @@ public class TypicalTestTasks {
         }
     }
 
-    public static void loadAddressBookWithSampleData(TaskBook ab) {
-        ab.addTask(new Task(alice));
-        ab.addTask(new Task(benson));
-        ab.addTask(new Task(carl));
-        ab.addTask(new Task(daniel));
-        ab.addTask(new Task(elle));
-        ab.addTask(new Task(fiona));
-        ab.addTask(new Task(george));
+    public static void loadAddressBookWithSampleData(TaskBook ab) throws IllegalValueException {
+        ab.addTask(new FloatingTask("alice"));
+        ab.addTask(new FloatingTask("benson"));
+        ab.addTask(new FloatingTask("carl"));
+        ab.addTask(new FloatingTask("daniel"));
+        ab.addTask(new FloatingTask("elle"));
+        ab.addTask(new FloatingTask("fiona"));
+        ab.addTask(new FloatingTask("george"));
     }
 
     public TestTask[] getTypicalPersons() {
@@ -62,7 +63,12 @@ public class TypicalTestTasks {
 
     public TaskBook getTypicalAddressBook() {
         TaskBook ab = new TaskBook();
-        loadAddressBookWithSampleData(ab);
+        try {
+			loadAddressBookWithSampleData(ab);
+		} catch (IllegalValueException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
         return ab;
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalTestTasks.java
+++ b/src/test/java/seedu/address/testutil/TypicalTestTasks.java
@@ -3,7 +3,6 @@ package seedu.address.testutil;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.TaskBook;
 import seedu.address.model.task.FloatingTask;
-import seedu.address.model.task.Task;
 
 /**
  *
@@ -64,11 +63,11 @@ public class TypicalTestTasks {
     public TaskBook getTypicalAddressBook() {
         TaskBook ab = new TaskBook();
         try {
-			loadAddressBookWithSampleData(ab);
-		} catch (IllegalValueException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+            loadAddressBookWithSampleData(ab);
+        } catch (IllegalValueException e) {
+
+            e.printStackTrace();
+        }
         return ab;
     }
 }


### PR DESCRIPTION
20->19 instantiating of Task
Parser: remove the need to return new AddCommand, which instantiates Task.
Parser: when add is entered as input, switch case calls prepareCommand(arguments). Removed `return new AddCommand` from `prepareCommand` method, and enable `prepareCommand` method to identify the type of task based on number of arguments entered, and then from there return new the specific type of parser. This change allows the code to be a step closer to userguide 

prev command input format:
`task` 
`due`
`event`

now:
`add`
