### PR TITLE
[URGENT BUG FIX] ObservableListChangeListener: use atomic operations

### DIFF
--- a/src/main/java/seedu/address/commons/util/ObservableListChangeListener.java
+++ b/src/main/java/seedu/address/commons/util/ObservableListChangeListener.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.util;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
@@ -8,22 +10,24 @@ import javafx.collections.ObservableList;
  */
 public class ObservableListChangeListener {
 
-    private boolean hasChanged = false;
+    // We use an AtomicBoolean because the event listeners may be called from another thread.
+    private final AtomicBoolean hasChanged;
 
     public ObservableListChangeListener(ObservableList<?>... lists) {
+        hasChanged = new AtomicBoolean(false);
         for (ObservableList<?> list : lists) {
             list.addListener((ListChangeListener.Change<? extends Object> change) -> {
-                hasChanged = true;
+                hasChanged.set(true);
             });
         }
     }
 
     public void setHasChanged(boolean hasChanged) {
-        this.hasChanged = hasChanged;
+        this.hasChanged.set(hasChanged);
     }
 
     public boolean getHasChanged() {
-        return hasChanged;
+        return hasChanged.get();
     }
 
 }


### PR DESCRIPTION
There is a bug where even though the task book has changed, the task
book was not being saved at all.

Presently (in LogicManager.java), we use a TaskBookChangeListener (which
inherits from ObservableListChangeListener) to monitor a task book from
changes. However, seemingly despite the fact that the task book was
modified, the ObservableListChangeListener was still returning
hasChanged = false!

It turns out that change listeners on an observable list may be called
from a different thread, and this was causing memory synchronization
problems. Fix this by using atomic operations instead.
