### PR TITLE
ObservableListChangeListener: keep references to the ObservableLists

### DIFF
--- a/src/main/java/seedu/address/commons/util/ObservableListChangeListener.java
+++ b/src/main/java/seedu/address/commons/util/ObservableListChangeListener.java
@@ -10,7 +10,12 @@ public class ObservableListChangeListener {
 
     private boolean hasChanged = false;
 
+    private final ObservableList<?>[] lists;
+
     public ObservableListChangeListener(ObservableList<?>... lists) {
+        // Store a reference to the observable lists so they do not get GC'd
+        this.lists = lists;
+        // Install our listeners on the observable lists
         for (ObservableList<?> list : lists) {
             list.addListener((ListChangeListener.Change<? extends Object> change) -> {
                 hasChanged = true;


### PR DESCRIPTION
There is a bug where even though the task book has changed, the task
book was not being saved at all.

Presently (in LogicManager.java), we use a TaskBookChangeListener (which
inherits from ObservableListChangeListener) to monitor a task book from
changes. However, seemingly despite the fact that the task book was
modified, the ObservableListChangeListener was still returning
hasChanged = false!

It turns out that because ObservableListChangeListener did not keep a
reference to the ObservableLists it was supposed to observe, these
ObservableLists were getting GC'd. As such, the
ObservableListChangeListener did not get the change events that it
expected.

Fix this by keeping a reference to the observable lists.
