### PR TITLE
build.gradle: remove unnecessary repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
-    maven { url "https://repo.eclipse.org/content/repositories/egit-releases/" }
-    maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
https://repo.eclipse.org/content/repositories/egit-releases/ has
suddenly died, which makes the gradle build get stuck at:

```
> Building 0% > :compileJava > Resolving dependencies ':compileClasspath'
```

because it tries to contact the above repository but does not get any
response.

Taking a look at what dependencies are currently in build.gradle, we
actually do not need the above repository at all.

As such, let's take this opportunity to remove all the repositories that
we do not actually need, so something like this is less likely to happen
again (unless maven central goes kaput).
