### PR TITLE
Rebase #126

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -9,6 +9,8 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.storage.DataSavingExceptionEvent;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.RedoCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.TaskTrackerParser;
 import seedu.address.model.Model;
 import seedu.address.model.TaskBookChangeListener;
@@ -45,6 +47,10 @@ public class LogicManager extends ComponentManager implements Logic {
         final CommandResult result = command.execute();
         updateConfigStorage(oldConfig);
         updateTaskBookStorage(taskBookListener);
+
+        if (model.hasUncommittedChanges() && !(command instanceof UndoCommand) && !(command instanceof RedoCommand) ) {
+            model.recordState(command);
+        }
         return result;
     }
 

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.ModelManager.HeadAtBoundaryException;
+
+public class RedoCommand extends Command {
+
+    public static final String COMMAND_WORD = "redo";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n" + "Redo the previous undo.\n\t" + "Example: " + COMMAND_WORD;
+
+    @Override
+    public CommandResult execute() {
+        Command action;
+        try {
+            action = model.redo();
+        } catch (HeadAtBoundaryException e) {
+            return new CommandResult("No undos to redo.");
+        }
+        return new CommandResult("Redid " + action.toString());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/RedoTraceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoTraceCommand.java
@@ -1,0 +1,13 @@
+package seedu.address.logic.commands;
+
+public class RedoTraceCommand extends Command {
+
+    public static final String COMMAND_WORD = "redo-trace";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n" + "Show a list of redoable actions\n\t" + "Example: " + COMMAND_WORD;
+
+    @Override
+    public CommandResult execute() {
+        return new CommandResult(model.printRedoables());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.ModelManager.HeadAtBoundaryException;
+
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "undo";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n" + "Undos previous action that modifies address book information.\n\t"
+            + "Example: " + COMMAND_WORD;
+
+    @Override
+    public CommandResult execute() {
+
+        Command undoneAction;
+        try {
+            undoneAction = model.undo();
+        } catch (HeadAtBoundaryException e) {
+            return new CommandResult("No actions to undo.");
+        }
+        return new CommandResult("Successfully undid previous " + undoneAction.toString());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/UndoTraceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoTraceCommand.java
@@ -1,0 +1,12 @@
+package seedu.address.logic.commands;
+
+public class UndoTraceCommand extends Command {
+    public static final String COMMAND_WORD = "undo-trace";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n" + "Show a list of undoable actions\n\t" + "Example: " + COMMAND_WORD;
+
+    @Override
+    public CommandResult execute() {
+        return new CommandResult(model.printUndoables());
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -4,6 +4,8 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.Command;
+import seedu.address.model.ModelManager.HeadAtBoundaryException;
 import seedu.address.model.config.ReadOnlyConfig;
 import seedu.address.model.task.DeadlineTask;
 import seedu.address.model.task.EventTask;
@@ -104,5 +106,37 @@ public interface Model {
      * If predicate is null, the filtered event task list will be populated with all event tasks.
      */
     void setEventTaskFilter(Predicate<? super EventTask> predicate);
+
+    ////undo redo
+
+    /**
+     * saves a copy of the current TaskBook, and the Command that causes the change from the previous TaskBook to the current TaskBook.
+     * @param command
+     */
+    void recordState(Command command);
+
+    /**
+     * resets the TaskBook to the TaskBook before it was changed by the most recent undo.
+     * @return the Command that was redone
+     * @throws HeadAtBoundaryException
+     */
+    Command redo() throws HeadAtBoundaryException;
+
+    /**
+     * resets the TaskBook to it's previous state.
+     * @return the Command that was undone
+     * @throws HeadAtBoundaryException
+     */
+    Command undo() throws HeadAtBoundaryException;
+
+    /**
+     *@return true if TaskBook has changed
+     *Unlikely the commits list will be empty since recordState() is called when ModelManager is initialised. Thus there will always be at least one Commit in commits.
+     */
+    boolean hasUncommittedChanges();
+
+    String printRedoables();
+
+    String printUndoables();
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -1,5 +1,6 @@
 package seedu.address.model;
 
+import java.util.ArrayList;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -9,6 +10,7 @@ import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.TaskBookChangedEvent;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.Command;
 import seedu.address.model.config.Config;
 import seedu.address.model.config.ReadOnlyConfig;
 import seedu.address.model.task.DeadlineTask;
@@ -28,6 +30,10 @@ public class ModelManager extends ComponentManager implements Model {
     private final FilteredList<DeadlineTask> filteredDeadlineTasks;
     private final FilteredList<EventTask> filteredEventTasks;
 
+    //for undo
+    private ArrayList<Commit> commits = new ArrayList<Commit>();
+    private int head; //head points to a the current commit which holds the TaskBook displayed by the UI
+
     /**
      * Initializes a ModelManager with the given config and TaskBook
      * TaskBook and its variables should not be null
@@ -43,6 +49,7 @@ public class ModelManager extends ComponentManager implements Model {
         this.filteredFloatingTasks = new FilteredList<>(this.taskBook.getFloatingTasks());
         this.filteredDeadlineTasks = new FilteredList<>(this.taskBook.getDeadlineTasks());
         this.filteredEventTasks = new FilteredList<>(this.taskBook.getEventTasks());
+        recordState(null);
     }
 
     public ModelManager() {
@@ -233,6 +240,91 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public void setEventTaskFilter(Predicate<? super EventTask> predicate) {
         filteredEventTasks.setPredicate(predicate);
+    }
+
+    ////undo redo
+
+    @Override
+    public Command undo() throws HeadAtBoundaryException {
+        if (head <= 0) {
+            throw new HeadAtBoundaryException();
+        }
+        Command undoneAction = commits.get(head).getCommand();
+        head--;
+        Commit commit = commits.get(head);
+        resetTaskBook(new TaskBook(commit.getTaskBook()));
+        return undoneAction;
+    }
+
+    @Override
+    public void recordState(Command command) {
+        //clear redoable, which are the commits above head
+        head ++;
+        while (this.head < (commits.size())) {
+            commits.remove(head);
+        }
+        commits.add(new Commit(command, new TaskBook(getTaskBook())));
+        head = commits.size() - 1;
+    }
+
+    @Override
+    public Command redo() throws HeadAtBoundaryException {
+        if (head >= commits.size() - 1) {
+            throw new HeadAtBoundaryException();
+        }
+        head++;
+        Commit commit = commits.get(head);
+        resetTaskBook(new TaskBook(commit.getTaskBook()));
+        return commit.getCommand();
+    }
+
+    /**
+     * check if taskBook has changed.
+     * @return true if TaskBook changed
+     */
+    @Override
+    public boolean hasUncommittedChanges() {
+        return !(this.taskBook.equals(commits.get(commits.size() - 1).getTaskBook()));
+    }
+
+    public String printUndoables() {
+        String trace = "";
+        for (int i = head; i > 0 ; i--) {
+            trace += commits.get(i).getCommand() + "\n";
+        }
+        return trace;
+    }
+
+    public String printRedoables() {
+        String trace = "";
+        for (int i = head; i < commits.size() ; i++) {
+            trace += commits.get(i).getCommand() + "\n";
+        }
+        return trace;
+    }
+
+    private class Commit {
+        private TaskBook taskBook;
+        private Command command;
+
+        Commit(Command command, TaskBook state) {
+            this.taskBook = state;
+            this.command = command;
+        }
+
+        public TaskBook getTaskBook() {
+            return this.taskBook;
+        }
+
+        public Command getCommand() {
+            return this.command;
+        }
+    }
+
+    public class HeadAtBoundaryException extends Exception {
+        public HeadAtBoundaryException() {
+            super();
+        }
     }
 
 }

--- a/src/test/java/seedu/address/model/ModelTest.java
+++ b/src/test/java/seedu/address/model/ModelTest.java
@@ -1,6 +1,8 @@
 package seedu.address.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,6 +13,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.ModelManager.HeadAtBoundaryException;
 import seedu.address.model.task.TypicalDeadlineTasks;
 import seedu.address.model.task.TypicalEventTasks;
 import seedu.address.model.task.TypicalFloatingTasks;
@@ -183,6 +189,217 @@ public class ModelTest {
     public void setDeadlineTask_invalidIndex_throwsException() throws Exception {
         thrown.expect(IllegalValueException.class);
         model.setDeadlineTask(0, tpdue.speechTranscript);
+    }
+
+    @Test
+    public void undo_redo_throws_HeadAtBoundaryException() throws HeadAtBoundaryException {
+        thrown.expect(HeadAtBoundaryException.class);
+        model.undo();
+
+        thrown.expect(HeadAtBoundaryException.class);
+        model.redo();
+    }
+
+    @Test
+    public void hasUncommitedChanges_manages_clear() {
+        //check for empty taskbook
+        assertEquals(new TaskBook(), model.getTaskBook());
+
+        //clear an empty taskbook
+        Command clear = new ClearCommand();
+        clear.setData(model);
+        clear.execute();
+        assertFalse(model.hasUncommittedChanges());
+
+        //create dummy command to store in record state
+        Command dummy = null;
+
+        //clear a non-empty taskbook
+        model.addFloatingTask(tpflt.buyAHelicopter);
+        model.recordState(dummy);
+        clear.setData(model);
+        clear.execute();
+        assertTrue(model.hasUncommittedChanges());
+    }
+
+    @Test
+    public void recordStateAndUndo_Redo_properlyUndosConsecutiveAdds() throws Exception {
+        // These are just dummy commands that test that recordState() correctly stores them, but does not
+        // execute them.
+        Command command1 = new Command() {
+            @Override
+            public CommandResult execute() {
+                assert false;
+                return new CommandResult("");
+            }
+        };
+        Command command2 = new Command() {
+            @Override
+            public CommandResult execute() {
+                assert false;
+                return new CommandResult("");
+            }
+        };
+
+        Command command3 = new Command() {
+            @Override
+            public CommandResult execute() {
+                assert false;
+                return new CommandResult("");
+            }
+        };
+
+        //create expected TaskBook
+        TaskBook dummybook = new TaskBook();
+
+        //Model task book is initially empty
+        assertEquals(dummybook, model.getTaskBook());
+
+        //We 'execute' command1
+        model.addFloatingTask(tpflt.buyAHelicopter);
+        model.recordState(command1);
+
+        //update expected TaskBook
+        dummybook.addFloatingTask(tpflt.buyAHelicopter);
+
+        //We 'execute' command2
+        model.addFloatingTask(tpflt.readABook);
+        model.recordState(command2);
+
+        //update expected TaskBook
+        dummybook.addFloatingTask(tpflt.readABook);
+
+        //We 'execute' command3
+        model.addEventTask(tpent.launchNuclearWeapons);
+        model.recordState(command3);
+
+        //update expected TaskBook
+        dummybook.addEventTask(tpent.launchNuclearWeapons);
+        TaskBook dummybook3 = new TaskBook(dummybook); //dummybook3 has float:[buyAHelicopter, readAbook], event:[launchNuclearWeapons]
+
+        assertEquals(dummybook, model.getTaskBook());
+
+        //undo command 3
+        assertEquals(command3, model.undo());
+
+        //update expected TaskBook
+        dummybook.removeEventTask(0);
+        TaskBook dummybook2 = new TaskBook(dummybook); //dummybook2 has float:[buyAHelicopter, readAbook]
+
+        //test
+        assertEquals(dummybook, model.getTaskBook());
+
+        //undo command 2
+        assertEquals(command2, model.undo());
+
+        //update expected taskbook
+        dummybook.removeFloatingTask(1);
+        TaskBook dummybook1 = new TaskBook(dummybook); //dummybook1 has float:[buyAHelicopter]
+
+        //test
+        assertEquals(dummybook, model.getTaskBook());
+
+        //undo command 1
+        assertEquals(command1, model.undo());
+
+        //update expected taskbook
+        dummybook.removeFloatingTask(0); //empty taskbook
+
+        //test
+        assertEquals(new TaskBook(), dummybook);
+        assertEquals(dummybook, model.getTaskBook());
+
+        //consecutive redos
+        //redo command1
+        assertEquals(command1, model.redo());
+        assertEquals(dummybook1, model.getTaskBook());
+
+        //redo command2
+        assertEquals(command2, model.redo());
+        assertEquals(dummybook2, model.getTaskBook());
+
+        //redo command3
+        assertEquals(command3, model.redo());
+        assertEquals(dummybook3, model.getTaskBook());
+
+        //no more redos expected
+        thrown.expect(HeadAtBoundaryException.class);
+        model.redo();
+    }
+
+    @Test
+    public void recordStateAndUndo_properlyManagesStack() throws Exception {
+        // These are just dummy commands that test that recordState() correctly stores them, but does not
+        // execute them.
+        Command command1 = new Command() {
+            @Override
+            public CommandResult execute() {
+                assert false;
+                return new CommandResult("");
+            }
+        };
+        Command command2 = new Command() {
+            @Override
+            public CommandResult execute() {
+                assert false;
+                return new CommandResult("");
+            }
+        };
+
+        Command command3 = new Command() {
+            @Override
+            public CommandResult execute() {
+                assert false;
+                return new CommandResult("");
+            }
+        };
+
+        // Model task book is initially empty
+        assertEquals(new TaskBook(), model.getTaskBook());
+
+        // We "execute" command1, adding a floating task
+        model.addFloatingTask(tpflt.buyAHelicopter);
+        model.recordState(command1);
+
+        // Undo command1
+        assertEquals(command1, model.undo());
+        assertEquals(new TaskBook(), model.getTaskBook()); // Model task book is back to being empty
+
+        // We "execute" command2, adding an event
+        model.addEventTask(tpent.lunchWithBillGates);
+        model.recordState(command2);
+
+        // Undo command2
+        assertEquals(command2, model.undo());
+        assertEquals(new TaskBook(), model.getTaskBook()); // Model task book is back to being empty
+
+        // At this point, we should not be able to undo anymore.
+        thrown.expect(HeadAtBoundaryException.class);
+        model.undo();
+
+        //We "execute" command 3, adding an event
+        model.addEventTask(tpent.launchNuclearWeapons);
+        model.recordState(command3);
+
+        //undo command3
+        assertEquals(command3, model.undo());
+        assertEquals(new TaskBook(), model.getTaskBook()); // Model task book is back to being empty
+
+        // We "execute" command1, adding a floating task
+        model.addFloatingTask(tpflt.buyAHelicopter);
+        model.recordState(command1);
+
+        // Undo command1
+        assertEquals(command1, model.undo());
+        assertEquals(new TaskBook(), model.getTaskBook()); // Model task book is back to being empty
+
+        // We "execute" command2, adding an event
+        model.addEventTask(tpent.lunchWithBillGates);
+        model.recordState(command2);
+
+        // Undo command2
+        assertEquals(command2, model.undo());
+        assertEquals(new TaskBook(), model.getTaskBook()); // Model task book is back to being empty
     }
 
 }


### PR DESCRIPTION
recordState when command (exceot undo and redo) changes taskbook

create Redo Command

Create Undo Command

fix undo bug
prev: undo returns the wrong command, but resets the taskbook to the correct state
now: undo returns the command that happened after the state which the taskbook is reset to.

add comment for head

add documentation for methods

replace IllegalValueException with own HeadAtBoundaryException

Parser recognises undo redo commands

fix bugs

create redo trace and undo trace Commands

Parse rcognises redo trace and undo trace

print available undos and redos using undo-trace, redo-trace

test

clear redoables before throwing on a commit into commits list

import exception

add consecutive undo test and hasUncommitedChanges

add redo test
