### PR TITLE
Date/Time parser fixes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DateParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateParser.java
@@ -39,6 +39,7 @@ public class DateParser implements Parser<LocalDate> {
 
     @Override
     public LocalDate parse(String str) throws ParseException {
+        assert str != null;
         final Optional<LocalDate> nameDate = parseAsName(str.trim());
         if (nameDate.isPresent()) {
             return nameDate.get();

--- a/src/main/java/seedu/address/logic/parser/DateParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateParser.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.util.Optional;
 
@@ -24,7 +25,8 @@ public class DateParser implements Parser<LocalDate> {
                 .appendPattern("d[/M[/uuuu]]")
                 .parseDefaulting(ChronoField.MONTH_OF_YEAR, this.referenceDate.getMonthValue())
                 .parseDefaulting(ChronoField.YEAR, this.referenceDate.getYear())
-                .toFormatter();
+                .toFormatter()
+                .withResolverStyle(ResolverStyle.STRICT);
     }
 
     public DateParser() {

--- a/src/test/java/seedu/address/logic/parser/DateParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 
@@ -54,9 +55,12 @@ public class DateParserTest {
         assertEquals(expected, actual);
     }
 
-    private void assertParseFail(String str) throws Exception {
-        thrown.expect(IllegalValueException.class);
-        parser.parse(str);
+    private void assertParseFail(String str) {
+        try {
+            parser.parse(str);
+            fail("IllegalValueException was not thrown");
+        } catch (IllegalValueException e) {
+        }
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/DateParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateParserTest.java
@@ -33,21 +33,39 @@ public class DateParserTest {
 
     @Test
     public void parse() throws Exception {
+        // Supported constants
         assertParse("tdy", TEST_DATE);
         assertParse("tmr", TEST_DATE.plusDays(1));
         assertParse("yst", TEST_DATE.minusDays(1));
+
+        // Different components present/missing
         assertParse(" 1 ", LocalDate.of(2015, 3, 1));
         assertParse("1/2", LocalDate.of(2015, 2, 1));
         assertParse("1/2/2014", LocalDate.of(2014, 2, 1));
+
+        // Min and max days
         assertParseFail("0/1/2016"); // No such day
-        assertParseFail("1/0/2015"); // No such month
-        assertParseFail("1/13/2015"); // No such month
         assertParse("31/12/2014", LocalDate.of(2014, 12, 31)); // December has 31 days
         assertParseFail("31/9/2016"); // September only has 30 days
         assertParse("29/2/2016", LocalDate.of(2016, 2, 29)); // A leap year
         assertParseFail("29/2/2015"); // Not a leap year
+
+        // Min and max months
+        assertParseFail("1/0/2015"); // No such month
+        assertParseFail("1/13/2015"); // No such month
+
+        // Min and max years
         assertParseFail("1/2/14"); // We don't support 2-digit years
+        assertParse("1/1/0000", LocalDate.of(0, 1, 1));
+        assertParse("1/1/9999", LocalDate.of(9999, 1, 1));
+
         assertParseFail("not a date at all");
+    }
+
+    @Test
+    public void parse_nullString_throwsAssertionError() throws Exception {
+        thrown.expect(AssertionError.class);
+        parser.parse(null);
     }
 
     private void assertParse(String str, LocalDate expected) throws Exception {

--- a/src/test/java/seedu/address/logic/parser/TimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TimeParserTest.java
@@ -28,14 +28,30 @@ public class TimeParserTest {
 
     @Test
     public void parse() throws Exception {
+        // Missing minute component
         assertParse("  4am  ", LocalTime.of(4, 0));
+
+        // . and : accepted, but must precede minute component
         assertParse("1.23pm", LocalTime.of(13, 23));
         assertParse("2:45am", LocalTime.of(2, 45));
+        assertParseFail("5:am");
+
+        // Hours (0-12)am/pm
         assertParse("12am", LocalTime.of(0, 0));
+        assertParse("0am", LocalTime.of(0, 0)); // Yeah, we accept 0am because some people do use it apparently (?)
+        assertParse("0pm", LocalTime.of(12, 0)); // Same for 0pm.
         assertParse("12pm", LocalTime.of(12, 0));
         assertParseFail("13am");
+
+        // Minutes (0-59)
+        assertParse("4:00am", LocalTime.of(4, 0));
+        assertParse("4:59am", LocalTime.of(4, 59));
+        assertParseFail("4:60am");
         assertParseFail("4:99am");
-        assertParseFail("5:am");
+
+        // Must have two minute digits
+        assertParseFail("4:0am");
+
         assertParseFail("not a time at all");
     }
 

--- a/src/test/java/seedu/address/logic/parser/TimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TimeParserTest.java
@@ -1,22 +1,18 @@
 package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.time.LocalTime;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 
 public class TimeParserTest {
 
     private static final LocalTime TEST_TIME = LocalTime.of(3, 14);
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private TimeParser parser;
 
@@ -48,9 +44,12 @@ public class TimeParserTest {
         assertEquals(expected, actual);
     }
 
-    private void assertParseFail(String str) throws Exception {
-        thrown.expect(IllegalValueException.class);
-        parser.parse(str);
+    private void assertParseFail(String str) {
+        try {
+            parser.parse(str);
+            fail("IllegalValueException was not thrown");
+        } catch (IllegalValueException e) {
+        }
     }
 
 }


### PR DESCRIPTION
The date and time parsers were actually subtly broken, and the tests did not catch them because the tests themselves were broken >:(